### PR TITLE
restricts a css rule to only apply on sidebar to fix lists

### DIFF
--- a/theme/saas/static/css/shippable.css
+++ b/theme/saas/static/css/shippable.css
@@ -180,12 +180,12 @@ body {
   padding-top: 50px;
 }
 
-menu,ol,small,ul {
+menu,ol.shipNav,small,ul.shipNav {
   margin: 0;
   padding: 0;
 }
 
-menu,ol,ul {
+menu,ol.shipNav,ul.shipNav {
   list-style: none;
 }
 


### PR DESCRIPTION
fixes https://github.com/Shippable/docs/issues/81

### Before
![image](https://cloud.githubusercontent.com/assets/5207331/25069227/c4cec508-2298-11e7-93df-f789bbbc3356.png)

### After  (extra html was removed after taking screenshot)
![image](https://cloud.githubusercontent.com/assets/5207331/25069226/be26cc96-2298-11e7-8e07-10d5fedc8f36.png)
