### PR TITLE
#389; adds IS_SERVER to admiral.env documentation.

### DIFF
--- a/sources/reference/admiral-onebox.md
+++ b/sources/reference/admiral-onebox.md
@@ -159,9 +159,6 @@ The Shippable UI used for enabling projects and viewing builds.
 
 ### Optional Services
 
-#### braintree
-This is used for processing payments and does not run by default.
-
 #### certgen
 This will run if either Kubernetes or Joyent Triton Public Cloud is enabled in the add-ons panel and is used to generate certificates.
 
@@ -173,9 +170,6 @@ Sends email notifications and will only be started if there is an email provider
 
 #### hipchat
 Sends Hipchat notifications and will only run if Hipchat is selected in the add-ons panel.
-
-#### hubspotSync
-This is used to update records in Hubspot and does not run by default.
 
 #### irc
 Sends IRC notifications and will only run if IRC is selected in the add-ons panel.
@@ -191,9 +185,6 @@ Part of the dynamic node provisioning; this will only run if AWS keys are provid
 
 #### provision
 Processes provision-type pipeline jobs; this will only run if Google Container Engine is enabled in add-ons.
-
-#### segmentListener
-This does not run by default.
 
 #### slack
 Sends Slack notifications; this only runs if Slack is selected in the add-ons section.

--- a/sources/reference/admiral.md
+++ b/sources/reference/admiral.md
@@ -122,6 +122,7 @@ The following values are stored in `admiral.env`:
 - SECRET_KEY: The installer secret key entered when first running `./admiral.sh install`. This is used to pull Docker images.
 - SERVICE_USER_TOKEN: The Shippable API token created for the internal service user. This will be set by Admiral when initializing the database.
 - RELEASE: The current Admiral release version. Set by `./admiral.sh install`, this will be set to the repository tag.
+- IS_SERVER: This should be `true`.
 - DB_PORT: The database port, set by `./admiral.sh install`.
 - DB_USER: The user that Admiral and Shippable API will use to connect to the database. This will be `apiuser`.
 - DB_NAME: The name of the database used by Admiral and Shippable API. This will be `shipdb`.


### PR DESCRIPTION
#389 

Adds `IS_SERVER` and removes braintree, hubspotSync, and segmentListener.