### PR TITLE
#409; adds documentation for Pipelines on_cancel notifications.

### DIFF
--- a/sources/deploy/send-notifications.md
+++ b/sources/deploy/send-notifications.md
@@ -78,12 +78,14 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 
 ```
   - name: your-job-name
-    type: yout-job-type
+    type: your-job-type
     on_start:
       - NOTIFY: <notification resource name>
     on_success:
       - NOTIFY: <notification resource name>
     on_failure:
+      - NOTIFY: <notification resource name>
+    on_cancel:
       - NOTIFY: <notification resource name>
     always:
       - NOTIFY: <notification resource name>
@@ -92,4 +94,5 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 * `on_start` specifies that notifications are sent when the job starts.
 * `on_success` specifies that notifications are sent when the job completes successfully.
 * `on_failure` specifies that notifications are sent when the job fails.
-* `always` specifies that notifications are sent when the job succeeds or fails.
+* `on_cancel` specifies that notifications are sent when the job is canceled.
+* `always` specifies that notifications are sent when the job succeeds, fails, errors, or is canceled.

--- a/sources/provision/send-notifications.md
+++ b/sources/provision/send-notifications.md
@@ -78,12 +78,14 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 
 ```
   - name: your-job-name
-    type: yout-job-type
+    type: your-job-type
     on_start:
       - NOTIFY: <notification resource name>
     on_success:
       - NOTIFY: <notification resource name>
     on_failure:
+      - NOTIFY: <notification resource name>
+    on_cancel:
       - NOTIFY: <notification resource name>
     always:
       - NOTIFY: <notification resource name>
@@ -92,4 +94,5 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 * `on_start` specifies that notifications are sent when the job starts.
 * `on_success` specifies that notifications are sent when the job completes successfully.
 * `on_failure` specifies that notifications are sent when the job fails.
-* `always` specifies that notifications are sent when the job succeeds or fails.
+* `on_cancel` specifies that notifications are sent when the job is canceled.
+* `always` specifies that notifications are sent when the job succeeds, fails, errors, or is canceled.

--- a/sources/reference/job-runcli.md
+++ b/sources/reference/job-runcli.md
@@ -22,7 +22,6 @@ jobs:
       - IN: awsCLIConfig
       - TASK:
         - script: aws s3 ls
-    on_start:
 ````
 
 The snippet above shows a basic example with required tags for configuring a runCLI job.
@@ -63,6 +62,8 @@ jobs:
     on_failure:                                 #optional
       - script: echo 'This block executes if the TASK section fails'
       - NOTIFY: slackNotification
+    on_cancel:                                  #optional
+      - NOTIFY: slackNotification
     always:                                     #optional
       - script: echo 'This block executes if the TASK section succeeds or fails'
       - NOTIFY: slackNotification
@@ -75,14 +76,18 @@ configure your runCLI job with the parameters described below:
 that are executed when the job starts.
 
   - [on_success](job-runcli.md#on_success): Specify `script` or `NOTIFY`
-sections that executed only if the `TASK` section succeeds.
+sections that are executed only if the `TASK` section succeeds.
 
-  - [on_failure](job-runcli.md#on_success): Specify `script` or `NOTIFY`
-sections that executed only if the `TASK` section fails.
+  - [on_failure](job-runcli.md#on_failure): Specify `script` or `NOTIFY`
+sections that are executed only if the `TASK` section fails.
+
+  - [on_cancel](job-runcli.md#on_cancel): Specify `NOTIFY` sections to send
+notifications if the job is canceled.  This cannot run scripts.
 
   - [always](job-runcli.md#always): Specify `script` or `NOTIFY` sections that
 are always executed at the end of the job, regardless of whether the `TASK`
-section failed or succeeded.
+section failed or succeeded.  Scripts will not run if the job is canceled,
+but notifications will be sent.
 
 ## Configured CLI tools
 

--- a/sources/reference/job-runsh.md
+++ b/sources/reference/job-runsh.md
@@ -38,6 +38,8 @@ jobs:
     on_failure:                                 #optional
       - script: echo 'This block executes if the TASK section fails'
       - NOTIFY: slackNotification
+    on_cancel:                                  #optional
+      - NOTIFY: slackNotification
     always:                                     #optional
       - script: echo 'This block executes if the TASK section succeeds or fails'
       - NOTIFY: slackNotification
@@ -51,6 +53,7 @@ jobs:
 * `steps` section is where the steps of your custom job should be entered. You can have any number of `IN` and `OUT` resources depending on what your job needs. You can also have one `TASK` section where you can enter one or more of your custom scripts. Keep in mind that everything under the `steps` section executes sequentially.
 * `on_success` can be used to run scripts that only execute if the `TASK` section executes successfully. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).
 * `on_failure` can be used to run scripts that only execute if the `TASK` section fails. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).
+* `on_cancel` can be used to send notifications as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).
 * `always` can be used to run scripts that only execute if the `TASK` section succeeds or fails. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).
 
 ##Environment variables

--- a/sources/reference/jobs-overview.md
+++ b/sources/reference/jobs-overview.md
@@ -167,7 +167,7 @@ In addition to viewing logs for the latest run, you can also view logs for histo
 <a name="jobNotifications"></a>
 ## Sending job status notifications
 
-You can send notifications about job status by adding the `on_start`, `on_success`, or `on_failure` tags to any job of any type.
+You can send notifications about job status by adding the `on_start`, `on_success`, `on_failure`, or `on_cancel` tags to any job of any type.
 
 You will first need to define a [notification resource](/pipelines/resources/notification/) in your `shippable.resources.yml`.
 
@@ -182,6 +182,8 @@ Then, you can use that resource in your `shippable.jobs.yml` to configure when n
       - NOTIFY: <notification resource name>
     on_failure:
       - NOTIFY: <notification resource name>
+    on_cancel:
+      - NOTIFY: <notification resource name>
     always:
       - NOTIFY: <notification resource name>
 ```
@@ -189,4 +191,5 @@ Then, you can use that resource in your `shippable.jobs.yml` to configure when n
 * `on_start` specifies that notifications are sent when the job starts.
 * `on_success` specifies that notifications are sent when the job completes successfully.
 * `on_failure` specifies that notifications are sent when the job fails.
-* `always` specifies that notifications are sent when the job succeeds or fails.
+* `on_cancel` specifies that notifications are sent when the job is canceled.
+* `always` specifies that notifications are sent when the job succeeds, fails, errors, or is canceled.

--- a/sources/reference/resource-notification.md
+++ b/sources/reference/resource-notification.md
@@ -8,6 +8,7 @@ A `notification` resource is used to add a notification type so that you can sen
 * Job starts (on_start)
 * Job is completed successfully (on_success)
 * Job failed (on_failure)
+* Job canceled (on_cancel)
 
 Email, Hipchat, IRC and Slack notifications are supported for all job types as of now.
 
@@ -16,14 +17,14 @@ You can create a notification resource by adding it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: <string>				        #required
-    type: notification					#required
-    integration: <string>				#required for Slack, Hipchat
+  - name: <string>              #required
+    type: notification          #required
+    integration: <string>       #required for Slack and Hipchat
     pointer:
-      method: email ! irc       #required for email and IRC
+      method: email | irc       #required for email and IRC
       recipients:
-        - "#beta"				        #required
-        - "@trriplejay"			                #optional
+        - "#beta"               #required
+        - "@trriplejay"         #optional
 ```
 
 The events for which this notification is sent out are configured in the jobs yml.

--- a/sources/reference/shippable-jobs-yml.md
+++ b/sources/reference/shippable-jobs-yml.md
@@ -24,6 +24,8 @@ jobs:
       - NOTIFY: <notification resource name>
     on_failure:
       - NOTIFY: <notification resource name>
+    on_cancel:
+      - NOTIFY: <notification resource name>
     always:
       - NOTIFY: <notification resource name>
 
@@ -48,7 +50,9 @@ jobs:
 
 * `on_failure` specifies that notifications are sent when the job fails.
 
-* `always` specifies that notifications are sent when the job succeeds or fails.
+* `on_cancel` specifies that notifications are sent when the job is canceled.
+
+* `always` specifies that notifications are sent when the job succeeds, fails, errors, or is canceled.
 
 For a detailed explanation of the yml for each job type, visit the reference page for that specific job:
 

--- a/sources/release/send-notifications.md
+++ b/sources/release/send-notifications.md
@@ -78,7 +78,7 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 
 ```
   - name: your-job-name
-    type: yout-job-type
+    type: your-job-type
     on_start:
       - NOTIFY: <notification resource name>
     on_success:

--- a/sources/validate/send-notifications.md
+++ b/sources/validate/send-notifications.md
@@ -4,7 +4,7 @@ sub_section: Before you start
 
 # Sending job status notifications
 
-You can send notifications about job status by adding the `on_start`, `on_success`, or `on_failure` tags to any job of any type.
+You can send notifications about job status by adding the `on_start`, `on_success`, `on_failure`, or `on_cancel` tags to any job of any type.
 
 To set up notifications, follow the step below:
 
@@ -78,12 +78,14 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 
 ```
   - name: your-job-name
-    type: yout-job-type
+    type: your-job-type
     on_start:
       - NOTIFY: <notification resource name>
     on_success:
       - NOTIFY: <notification resource name>
     on_failure:
+      - NOTIFY: <notification resource name>
+    on_cancel:
       - NOTIFY: <notification resource name>
     always:
       - NOTIFY: <notification resource name>
@@ -92,4 +94,5 @@ You can use your resource in your `shippable.jobs.yml` to configure when notific
 * `on_start` specifies that notifications are sent when the job starts.
 * `on_success` specifies that notifications are sent when the job completes successfully.
 * `on_failure` specifies that notifications are sent when the job fails.
-* `always` specifies that notifications are sent when the job succeeds or fails.
+* `on_cancel` specifies that notifications are sent when the job is canceled.
+* `always` specifies that notifications are sent when the job succeeds, fails, errors, or is canceled.


### PR DESCRIPTION
#409 

Adds documentation for Pipelines notifications in `on_cancel`.  This should be available in the next deployment.