### PR TITLE
#448; adds replicate to runSh/runCLI.

### DIFF
--- a/sources/reference/job-runcli.md
+++ b/sources/reference/job-runcli.md
@@ -56,6 +56,7 @@ jobs:
         - script: <command>                     #optional
       - OUT: <resource>
       - OUT: <resource>
+        replicate: <resource>
     on_success:                                 #optional
       - script: echo 'This block executes after the TASK section executes successfully'
       - NOTIFY: slackNotification
@@ -88,6 +89,10 @@ notifications if the job is canceled.  This cannot run scripts.
 are always executed at the end of the job, regardless of whether the `TASK`
 section failed or succeeded.  Scripts will not run if the job is canceled,
 but notifications will be sent.
+
+  - [replicate](jobs-unmanaged#replicating-an-input): Adding `replicate` to
+an `OUT` resource will copy an `IN` resource for the new version of the `OUT`
+resource.
 
 ## Configured CLI tools
 

--- a/sources/reference/job-runsh.md
+++ b/sources/reference/job-runsh.md
@@ -32,6 +32,7 @@ jobs:
         - script: <command>
       - OUT: <resource>
       - OUT: <resource>
+        replicate: <resource>
     on_success:                                 #optional
       - script: echo 'This block executes after the TASK section executes successfully'
       - NOTIFY: slackNotification
@@ -51,6 +52,7 @@ jobs:
 * `type` indicates type of job. In this case it is always `runSh`
 * `on_start` can be used to send a notification indicating the job has started running.
 * `steps` section is where the steps of your custom job should be entered. You can have any number of `IN` and `OUT` resources depending on what your job needs. You can also have one `TASK` section where you can enter one or more of your custom scripts. Keep in mind that everything under the `steps` section executes sequentially.
+    * `replicate`: Adding [replicate](jobs-unmanaged#replicating-an-input) to an `OUT` resource will copy an `IN` resource for the new version of the `OUT` resource.
 * `on_success` can be used to run scripts that only execute if the `TASK` section executes successfully. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).
 * `on_failure` can be used to run scripts that only execute if the `TASK` section fails. You can also use this to send a notification as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).
 * `on_cancel` can be used to send notifications as shown in the example above. The `NOTIFY` tag is set to a [Slack notification resource](/reference/resource-notification/).

--- a/sources/reference/jobs-unmanaged.md
+++ b/sources/reference/jobs-unmanaged.md
@@ -280,6 +280,29 @@ createOutState() {
 
 ```
 
+<a name="replicating-an-input"></a>
+###Replicating an input to OUT resources
+
+You might want to update a resource with a copy of another resource in your job.  For example, if you have two image resources and want to update the second with the same tag as the first at the end of your job.  To do this, you can use the `replicate` option.
+
+Let us assume you want to copy the tag from myImage to myNewImage. This can be accomplished with the following `shippable.jobs.yml`:
+
+```
+jobs:
+  - name: myCustomJob
+    type: runSh
+    steps:
+      - IN: myImage
+      - IN: myRepo
+      - TASK:
+        - script: ./IN/myRepo/gitRepo/doSomething.sh
+      - OUT: myNewImage
+        replicate: myImage
+```
+
+The `replicate` option will copy all of the version information from the input resource to the output resource and will work with all output resources in unmanaged jobs.  Additional information, such as a different tag or updated params, may also be added to this version in the same way as versions created without `replicate`.
+
+
 <a name="extract-resource-info"></a>
 ###Extract IN resource information
 


### PR DESCRIPTION
#448 

Adds `replicate` to the documentation for unmanaged jobs.