### PR TITLE
adds documentation for using params resource variables directly

### DIFF
--- a/sources/reference/resource-params.md
+++ b/sources/reference/resource-params.md
@@ -45,4 +45,7 @@ For example, if you want to use different environment parameters (say database s
 In the picture above, `deploy-test` takes `params-1` as an input. After testing, a release is created with the `release` job. This triggers production deployment with the `deploy-prod` job, which takes `params-2` as an input. For this production deployment, we will use a superset of settings from `params-1` and `params-2`, with values for any common settings being chosen from `params-2`.
 
 ## Using params resources as inputs to runSh and runCLI jobs
-If a params resource is added as an input, the key-value pairs contained in the params resource are set as environment variables in the runSh or runCLI job. The naming convention for those variables is available in the documentation on [runSh environment variables](job-runsh/#resource-variables).
+If a params resource is added as an input, the key-value pairs contained in the params resource are set as environment variables in the runSh or runCLI job. The variables can be used by
+
+- following the naming convention for those variables available in the documentation on [runSh environment variables](job-runsh/#resource-variables).
+- directly using the variable name. If there are multiple params resources as INs to the runSh/runCLI jobs and if there are keys shared across the params resources, then the last value of that key will be used. This works similar to Bash export of variables. 


### PR DESCRIPTION
https://github.com/Shippable/docs/issues/461
In /reference/resource-params/#params
before
![params before](https://user-images.githubusercontent.com/7699231/28120597-21dd1218-6736-11e7-8fde-358b79796f62.png)

after
![params envs](https://user-images.githubusercontent.com/7699231/28120605-27d911da-6736-11e7-8b22-a5c6ba2e7e7c.png)
