### PR TITLE
update runSh docs to state cliConfigs can be configured with runSH jobs and updates cliConfig page to have the table of supported integrations

### DIFF
--- a/sources/platform/jobs-runsh.md
+++ b/sources/platform/jobs-runsh.md
@@ -19,7 +19,9 @@ page_keywords: Deploy multi containers, microservices, Continuous Integration, C
 
 You should use this job type if you need the freedom that some of the pre-packaged Jobs like `deploy`, `manifest` do not provide the flexibility that you need or do not support the 3rd party end-point you want to integrate to. For example, pushing to Heroku is not yet natively supported through a managed job type, so you can write the scripts needed to do this and add it to your workflow as a Job of type `runSh`.
 
-A new version is created anytime this Job is executed
+You can also add `cliConfig` resources as inputs to this job. The relevant CLI tools will be preconfigured for your scripts to use. For a complete list of supported cliConfig integrations see [here](resource-cliconfig#cliConfigTools).
+
+A new version is created anytime this Job is executed.
 
 You can create a `runSh` Job by [adding](jobs-working-wth#adding) it to `shippable.jobs.yml` and it executes on Shippable provided [Dynamic Nodes]() or [Custom Nodes]()
 

--- a/sources/platform/resource-cliconfig.md
+++ b/sources/platform/resource-cliconfig.md
@@ -31,7 +31,15 @@ resources:
 
 * **`integration`** -- name of the integration. Currently supported integrations are
 	* AWS
-	* GKE
+	* Amazon EC2 Container Registry (ECR)
+	* Docker Hub
+	* Docker Trusted Registry
+	* Google Container Engine (GKE)
+	* Google Container Registry (GCR)
+	* JFrog Artifactory
+	* Kubernetes
+	* Private Docker Registry
+	* Quay.io
 
 * **`pointer`** -- is an object which contains integration specific properties
 	* in case of AWS
@@ -48,6 +56,27 @@ resources:
 	      region: <aws region for e.g us-east-1, us-west-1 etc.>
 	      clusterName: <cluster of type Google Container Engine>
 	```
+
+<a name="cliConfigTools"></a>
+# Configured CLI tools
+
+The runCLI and runSh job uses the subscription integration specified in the
+cliConfig to determine which CLI tools to configure.
+These tools are configured with the credentials contained in the subscription
+integration. Here is a list of the tools configured for each integration type:
+
+| Integration Type                    | Configured Tools           |
+| ------------------------------------|-------------|
+| AWS                                 | [AWS CLI](https://aws.amazon.com/cli/); [EB (Elastic Beanstalk) CLI](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) |
+| Amazon EC2 Container Registry (ECR) | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
+| Docker Hub                          | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
+| Docker Trusted Registry             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
+| Google Container Engine             | [gcloud](https://cloud.google.com/sdk/gcloud/); [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) |
+| Google Container Registry (GCR)     | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
+| JFrog Artifactory                   | [JFrog CLI](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory) |
+| Kubernetes                          | [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) |
+| Private Docker Registry             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
+| Quay.io                             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
 
 # Used in JOBs
 This resource is used as an IN for the following jobs


### PR DESCRIPTION
https://github.com/Shippable/docs/issues/494

![image](https://user-images.githubusercontent.com/14016521/28705608-373e4d84-738e-11e7-80f9-5befdb159c1e.png)

![docs](https://user-images.githubusercontent.com/14016521/28705664-7afa9dfc-738e-11e7-9a1e-aa8f11440281.gif)
