### PR TITLE
adds docs for 5.8.2 SMI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -366,6 +366,7 @@ pages:
         - Caching: platform/tutorial/runtime/caching.md
         - Environment Variables: platform/tutorial/runtime/environment-variables.md
         - AMI Overview: platform/tutorial/runtime/ami-overview.md
+        - AMI v5.8.2: platform/tutorial/runtime/ami-v582.md
         - AMI v5.7.3: platform/tutorial/runtime/ami-v573.md
         - AMI v5.6.1: platform/tutorial/runtime/ami-v561.md
         - AMI v5.5.1: platform/tutorial/runtime/ami-v551.md

--- a/sources/ci/custom-docker-image.md
+++ b/sources/ci/custom-docker-image.md
@@ -79,7 +79,8 @@ integrations:
 * `integrationName` is the friendly name of the account integration you added. Please note that the name has to match exactly.
 * `type` depends on the registry you are pulling from:
     * `docker` for Docker Hub
-    * `ecr` for Amazon ECR
+    * `ecr` for Amazon ECR.
+        - Note: For running builds on docker version 17.06.0-ce and above, make sure that the `aws` cli installed in the image is 1.11.91 version or above.
     * `gcr` for Google Container Registry (GCR)
     * `"Docker Trusted Registry"` for Docker Trusted Registry
     * `quay` for Quay.io

--- a/sources/platform/runtime/cli/aws.md
+++ b/sources/platform/runtime/cli/aws.md
@@ -14,9 +14,10 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-[drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 - Latest | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+[drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+[drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 [drydock/u16all:v5.6.1](/platform/runtime/os/ubuntu16#v561)  | Jun 2017 | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 [drydock/u16all:v5.5.1](/platform/runtime/os/ubuntu16#v551)  | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 [drydock/u16all:v5.4.1](/platform/runtime/os/ubuntu16#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -25,9 +26,10 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-[drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 - Latest | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+[drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+[drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 [drydock/u14all:v5.6.1](/platform/runtime/os/ubuntu14#v561)  | Jun 2017 | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 [drydock/u14all:v5.5.1](/platform/runtime/os/ubuntu14#v551)  | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 [drydock/u14all:v5.4.1](/platform/runtime/os/ubuntu14#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -39,6 +41,7 @@ This table helps you choose the right tag based on the version of the CLI you mi
 
 | Version  |  Tags    
 |----------|---------
+|1.11.91  | v5.8.2
 |1.11.44  | v5.7.3 and below
 
 ## Further Reading

--- a/sources/platform/tutorial/runtime/ami-v582.md
+++ b/sources/platform/tutorial/runtime/ami-v582.md
@@ -1,0 +1,447 @@
+page_main_title: v5.8.2
+main_section: Platform
+sub_section: Tutorials
+sub_sub_section: Runtime
+page_title: Description of what is available in Machine Image v5.8.2
+page_description: A complete list of language versions, Docker versions, packages and tools available in Machine Image v5.8.2
+page_keywords: CI/CD, shippable CI/CD, documentation, shippable, config, yml, AMI, Docker
+
+# Machine image v5.8.2 (Docker TAG v5.8.2)
+
+**Release Date:** Jul 20, 2017
+
+**What is installed**
+
+* Operating System: Ubuntu 14.04.5 LTS
+* Kernel Version: 3.13.0-125-generic
+* **Docker Server Version: 17.06.0-ce**
+* Storage Driver: aufs
+* Root Dir: /data/aufs
+* Backing Filesystem: extfs
+* Dirperm1 Supported: false
+* Cgroup Driver: cgroupfs
+* Shippable Official Docker Images with TAG: `v5.8.2`
+
+## Shippable Official Docker Images
+These are the images used to run your CI jobs. The default image is picked up based on the `language` you set in your yml. All these images are available on our [Docker drydock Hub](https://hub.docker.com/u/drydock/). The source code is availabe on our [Github dry-dock org](https://github.com/dry-dock)
+
+If you would like to use your own CI images in place of the official images, instructions are [described here](/ci/custom-docker-image/)
+
+These are the official language images in this version
+
+* [Nodejs](#nod-582)
+* [Python](#pyt-582)
+* [Java](#jav-582)
+* [Ruby](#rub-582)
+* [GO](#gol-582)
+* [PHP](#php-582)
+* [Clojure](#clo-582)
+* [Scala](#sca-582)
+* [C/C++](#cpp-582)
+
+<a name="common-582"></a>
+### Common components installed
+
+All the images have these components pre-installed
+
+**Packages**
+
+* build-essential
+* curl
+* gcc
+* gettext
+* git
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* psmisc
+* python-dev
+* python-pip
+* python-software-properties
+* software-properties-common
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+
+**CLIs**
+
+* awscli 1.11.91
+* awsebcli 3.9
+* gcloud 160.0.0
+* jfrog-cli 1.7.0
+* kubectl 1.5.1
+* packer 0.12.2
+* terraform 0.8.7
+
+**Services on ubuntu 14.04**
+
+* cassandra 3.11
+* couchdb 1.6
+* elasticsearch 5.5.0
+* neo4j 3.2.2
+* memcached 1.4.39
+* mongodb 3.4.6
+* mysql 5.6
+* postgres 9.6.3
+* rabbitmq 3.6.10
+* redis 3.2.9
+* rethinkdb 2.3.5
+* riak 2.2.3
+* selenium 3.4.0
+* sqllite 3.19.3
+
+**Services on ubuntu 16.04**
+
+* cassandra 3.11
+* couchdb 1.6
+* elasticsearch 5.5.0
+* neo4j 3.2.2
+* memcached 1.4.39
+* mongodb 3.4.6
+* mysql 5.7.18
+* postgres 9.6.3
+* rabbitmq 3.6.10
+* redis 3.2.9
+* rethinkdb 2.3.5
+* riak 2.2.3
+* selenium 3.4.0
+* sqllite 3.19.3
+
+## Pre-installed official Docker Images
+This image ships with these pre-installed images to speed up your CI build process
+
+<a name="nod-582"></a>
+### Node.js
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14nodall/)
+	* [Github](https://github.com/dry-dock/u14nodall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16nodall/)
+	* [Github](https://github.com/dry-dock/u16nodall)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* 4.8.4
+* 5.12.0
+* 6.11.1
+* 7.10.1
+* 8.1.4
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* nvm
+* Java  1.8.0
+* Ruby 2.3.3
+* Yarn 0.24.5
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* nvm
+* Java  1.8.0
+* Ruby 2.3.3
+* Yarn 0.24.5
+
+---
+
+<a name="pyt-582"></a>
+### Python
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14pytall/)
+	* [Github](https://github.com/dry-dock/u14pytall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16pytall/)
+	* [Github](https://github.com/dry-dock/u16pytall)
+
+**Language Versions**
+These versions are pre-installed on ubuntu 14.04 image
+
+* 2.7.12
+* 3.4.3
+* 3.5.3
+* 3.6.1
+* pypy2 5.8.0
+* pypy3 5.8.0
+
+These versions are pre-installed on ubuntu 16.04 image
+
+* 2.7.12
+* 3.4.5
+* 3.5.2
+* 3.6.1
+* pypy2 5.8.0
+* pypy3 5.8.0
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* virtualenv
+* Java 1.8.0
+* Node 4.8.3
+* Ruby 2.3.3
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* virtualenv
+* Java 1.8.0
+* Node 7.10.0
+* Ruby 2.3.3
+
+---
+
+<a name="jav-582"></a>
+### Java
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14javall/)
+	* [Github](https://github.com/dry-dock/u14javall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16javall/)
+	* [Github](https://github.com/dry-dock/u16javall)
+
+**Language Versions**
+These versions are pre-installed on Ubuntu 14.04 image
+
+* openjdk7
+* openjdk8
+* oraclejdk8
+* oraclejdk9
+
+These versions are pre-installed on Ubuntu 16.04 image
+
+* openjdk7
+* openjdk8
+* openjdk9
+* oraclejdk8
+* oraclejdk9
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* Node 4.8.3
+* Ruby 2.3.3
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* Node 7.10.0
+* Ruby 2.3.3
+
+---
+
+
+<a name="rub-582"></a>
+### Ruby
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14ruball/)
+	* [Github](https://github.com/dry-dock/u14ruball)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16ruball/)
+	* [Github](https://github.com/dry-dock/u16ruball)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* 2.2.7
+* 2.3.4
+* 2.4.1
+* jruby 1.7.27
+* jruby 9.0.0
+* jruby 9.1.12
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* rvm 1.29.2
+* Java 1.8.0
+* Node 4.8.3
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* rvm 1.29.1
+* Java 1.8.0
+* Node 4.8.3
+
+---
+
+<a name="gol-582"></a>
+### GO
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14golall/)
+	* [Github](https://github.com/dry-dock/u14golall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16golall/)
+	* [Github](https://github.com/dry-dock/u16golall)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* 1.7.6
+* 1.8.3
+
+**Additional packages**
+
+* [Common components](#common-582)
+* gvm 1.0.22
+* Java 1.8.10
+* Node 4.8.3
+* Ruby 2.3.3
+
+---
+
+<a name="php-582"></a>
+### PHP
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14phpall/)
+	* [Github](https://github.com/dry-dock/u14phpall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16phpall/)
+	* [Github](https://github.com/dry-dock/u16phpall)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* 5.6.30
+* 7.0.20
+* 7.1.6
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* phpenv 1.1.1-2-g615f844
+* Java 1.8.0
+* Node 4.8.3
+* Ruby 2.3.3
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* phpenv 1.1.1-2-g615f844
+* Java 1.8.0
+* Node 7.10.0
+* Ruby 2.3.3
+---
+
+<a name="clo-582"></a>
+### Clojure
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14cloall/)
+	* [Github](https://github.com/dry-dock/u14cloall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16cloall/)
+	* [Github](https://github.com/dry-dock/u16cloall)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* 1.3.0
+* 1.4.0
+* 1.5.1
+* 1.6.0
+* 1.7.0
+* 1.8.0
+
+**Additional packages**
+
+* [Common components](#common-582)
+* leiningen
+* Java 1.8
+* Node 7.x
+* Ruby 2.3.3
+
+---
+
+<a name="sca-582"></a>
+### Scala
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14scaall/)
+	* [Github](https://github.com/dry-dock/u14scaall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16scaall/)
+	* [Github](https://github.com/dry-dock/u16scaall)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* 2.9.3
+* 2.10.6
+* 2.11.11
+* 2.12.2
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* sbt
+* Java 1.8.0
+* Node 4.8.3
+* Ruby 2.3.3
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* sbt
+* Java 1.8.0
+* Node 7.10.0
+* Ruby 2.3.3
+
+---
+
+
+<a name="cpp-582"></a>
+### C/C++
+**OS Versions**
+
+* Ubuntu 14.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u14cppall/)
+	* [Github](https://github.com/dry-dock/u14cppall)
+* Ubuntu 16.04
+	* [Docker Hub](https://hub.docker.com/r/drydock/u16cppall/)
+	* [Github](https://github.com/dry-dock/u16cppall)
+
+**Language Versions**
+These versions are pre-installed on both the OS version images
+
+* gcc 7.1
+* clang 4.0.0
+
+**Additional packages on ubuntu 14.04**
+
+* [Common components](#common-582)
+* Java 1.8.0
+* Node 4.8.3
+* Ruby 2.3.3
+
+**Additional packages on ubuntu 16.04**
+
+* [Common components](#common-582)
+* Java 1.8.0
+* Node 7.10.0
+* Ruby 2.3.3
+
+---


### PR DESCRIPTION
https://github.com/Shippable/docs/issues/510

This adds docs for 5.8.1 SMI. There is also a note in the custom-docker-image page that, if one is using their own image in CI, then aws cli version should be 1.11.91 or above for running builds on docker 17.06

![ecr note](https://user-images.githubusercontent.com/7699231/29125918-9d61f858-7d3a-11e7-8bda-3d2c99afee36.png)
