### PR TITLE
Fixes broken links and formatting in resources.

### DIFF
--- a/sources/platform/workflow/resource/cirepo.md
+++ b/sources/platform/workflow/resource/cirepo.md
@@ -4,11 +4,11 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # ciRepo
-This resource is simply a representation of a project that is enabled for Shippable CI.  This resource is automatically created when a project is enabled.  If your project is already enabled, you may need to click the "Hook" button on the project settings page.  This resource acts as an input to the [runCI job](/platform/workflow/job/runci/)
+This resource is simply a representation of a project that is enabled for Shippable CI.  This resource is automatically created when a project is enabled.  This resource acts as an input to the [runCI job](/platform/workflow/job/runci/).
 
-This resource cannot be configured via `shippable.resources.yml` at this time.  
+This resource cannot be configured via `shippable.resources.yml` at this time. If your project is already enabled and your subscription does not have a ciRepo resource, you may need to click the "Hook" button on the project settings page.
 
 
 # Further Reading
-* [Quick Start to CI](getting-started/ci-sample)
+* [Quick Start to CI](/getting-started/ci-sample)
 * [Resource](/platform/workflow/resource/overview)

--- a/sources/platform/workflow/resource/cliconfig.md
+++ b/sources/platform/workflow/resource/cliconfig.md
@@ -3,53 +3,47 @@ main_section: Platform
 sub_section: Workflow
 sub_sub_section: Resources
 
-# cliconfig
+# cliConfig
 `cliConfig` is a resource used to store configuration information needed to setup a Command Line Interface.
 
-You can create a `cliConfig` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
+You can create a `cliConfig` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`.
 
-Multiple cliConfig resources may be used as INs and their respective CLIs are configured automatically. If more than one cliConfig of the same integration type is added, the last one used in `IN` statements, wins.
+Multiple cliConfig resources may be used as `IN`s and their respective CLIs are configured automatically. If more than one cliConfig of the same integration type is added, the last one used in `IN` statements wins.
 
 ```
 resources:
-  - name: 			<string>
-    type: 			cliConfig
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           cliConfig
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `cliConfig`
 
-* **`integration`** -- name of the integration. Currently supported integrations are
-	* [AWS](integration/aws)
-	* [AWS ECR](integration/aws-ecr)
-	* [Docker Hub](integration/docker-hub)
-	* [Docker Trusted Registry](integration/docker-trusted-registry)
-	* [Docker Private Registry](integration/docker-private-registry)
-	* [Google Cloud](integration/gce)
-	* [Google Container Registry](integration/gcr)
-	* [Google Container Engine](integration/gke)
-	* [JFrog](integration/jfrog-artifactory)
-	* [Kubernetes](integration/kubernetes)
-	* [Quay](integration/quay)
+* **`integration`** -- name of the subscription integration. Currently supported integration types are:
+	* [Amazon ECR](/platform/integration/aws-ecr)
+	* [Docker Hub](/platform/integration/docker-hub)
+	* [Docker Trusted Registry](/platform/integration/docker-trusted-registry)
+	* [Docker Private Registry](/platform/integration/docker-private-registry)
+	* [Google Container Registry](/platform/integration/gcr)
+	* [Google Container Engine](/platform/integration/gke)
+	* [JFrog Artifactory](/platform/integration/jfrog-artifactory)
+	* [Kubernetes](/platform/integration/kubernetes)
+	* [Quay](/platform/integration/quay)
 
-* **`pointer`** -- is an object which contains integration specific properties
-	* in case of AWS
+* **`pointer`** -- is an object that contains integration specific properties
+	* For an Amazon ECR integration:
 
-	```
-	    pointer:
-	      region: <aws region for e.g us-east-1, us-west-1 etc.>
-	```
+	        pointer:
+	           region: <AWS region, e.g., us-east-1, us-west-1, etc.>
 
-	* in case of Google Integrations, if region and clusterName is provided `gcloud` and `kubectl` will be sutomatically configured to use it. If not provided, just the authentication to google cloud is done automatically
+	* For Google integrations, if region and clusterName are provided `gcloud` and `kubectl` will be automatically configured to use that region and cluster. If not provided, just the authentication to Google Cloud is done automatically.
 
-	```
-	    pointer:
-	      region: <aws region for e.g us-east-1, us-west-1 etc.>
-	      clusterName: <cluster of type Google Container Engine>
-	```
+	        pointer:
+	          region:      <region, e.g., us-central1-a, us-west1-b, etc.>
+	          clusterName: <cluster name>
 
 <a name="cliConfigTools"></a>
 ## Configured CLI tools
@@ -72,42 +66,37 @@ integration. Here is a list of the tools configured for each integration type:
 | Kubernetes                          | [kubectl](/platform/runtime/cli/kubectl) |
 | Quay.io                             | [Docker Engine](/platform/runtime/cli/docker) |
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+## Used in Jobs
+This resource is used as an `IN` for the following jobs
 
-* [runCI](workflow/job/runci/)
-* [runSh](workflow/job/runsh/)
+* [runCI](/platform/workflow/job/runci/)
+* [runSh](/platform/workflow/job/runsh/)
 
 ## Default Environment Variables
-Whenever `cliConfig` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `cliConfig` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `cliConfig`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `cliConfig`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_POINTER\_REGION 				| Region defined in the pointer. Available if the integration is AWS or Google |
-| `<NAME>`\_POINTER\_CLUSTERNAME 			| ClusterName defined in the pointer. Available if the integration is Google |
+| `<NAME>`\_POINTER\_REGION 				| Region defined in the pointer. Available if the integration is AWS or Google. |
+| `<NAME>`\_POINTER\_CLUSTERNAME 			| ClusterName defined in the pointer. Available if the integration is Google. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
-| `<NAME>`\_VERSIONNAME						| versionName of the version of the resource being used. |
+| `<NAME>`\_VERSIONNAME						| The versionName of the version of the resource being used. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)
 * [Resource](/platform/workflow/resource/overview)
 * [Supported CLIs](/platform/runtime/overview#cli)
-
-## TODO
-| Tasks   |      Status    |
-|----------|-------------|
-| Update Utility functions section|  Open |

--- a/sources/platform/workflow/resource/cluster.md
+++ b/sources/platform/workflow/resource/cluster.md
@@ -7,24 +7,23 @@ page_description: List of supported resources
 page_keywords: Deploy multi containers, microservices, Continuous Integration, Continuous Deployment, CI/CD, testing, automation, pipelines, docker, lxc
 
 # cluster
-`cluster` is used to represent a set of machines or a container orchestration system. It used to predominantly deploy services/apps to it and in some case it can also be used to run certain maintenance activities on the cluster as a whole.
+`cluster` is used to represent a set of machines or a container orchestration system. It is predominantly used to deploy services/apps to the specified cluster and in some cases it can also be used to run certain maintenance activities on the cluster as a whole.
 
 You can create a `cluster` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			cluster
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           cluster
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `cluster`
 
-* **`integration`** -- name of the integration. Currently supported integrations
-	* [AWS](/platform/integration/aws)
+* **`integration`** -- name of the subscription integration. Currently supported integration types are:
 	* [AWS Elastic Container Service (ECS)](/platform/integration/aws-ecs)
 	* [Azure Container Service](/platform/integration/azure-dcos)
 	* [Docker Cloud](/platform/integration/docker-cloud)
@@ -33,68 +32,62 @@ resources:
 	* [Kubernetes](/platform/integration/kubernetes)
 	* [Node Cluster](/platform/integration/node-cluster)
 
-* **`pointer`** -- is an object which contains integration specific properties
-	* For AWS integration
+* **`pointer`** -- is an object that contains integration specific properties
+	* For AWS integrations:
 
-	```
-	    pointer:
-	      region: <aws region for e.g us-east-1, us-west-1 etc.>
-	      sourceName: contains ECS cluster name
-	```
+	        pointer:
+	          region:     <AWS region, e.g., us-east-1, us-west-1, etc.>
+	          sourceName: <Amazon ECS cluster name>
 
-	* For Azure integration - NA
-	* For Kubernetes integration - NA
-	* For Docker Cloud integration
+	* For Azure integrations - N/A
+	* For Kubernetes integrations - N/A
+	* For Docker Cloud integrations,
 
-	```
-	    pointer:
-	      sourceName: <Docker Cloud Cluster Name>
-	```
+	        pointer:
+	          sourceName: <Docker Cloud Cluster Name>
 
-	* For Docker Datacenter - NA
-	* For Kubernetes integration - NA
-	* For GKE integration
+	* For Docker Datacenter integrations - N/A
+	* For Kubernetes integrations - N/A
+	* For GKE integrations:
 
-	```
-	    pointer:
-	      region: <aws region for e.g us-east-1, us-west-1 etc.>
-	      sourceName: <cluster of type Google Container Engine>
-	      namespace: optional if you want to specify which namespace you want to deploy to
-	```
+	        pointer:
+	          region:     <region, e.g., us-central1-a, us-west1-b, etc.>
+	          sourceName: <Google Container Engine cluster name>
+	          namespace:  <optional namespace you want to deploy to>
 
-	* For node Cluster - NA
+	* For Node Cluster integrations - N/A
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+## Used in Jobs
+This resource is used as an `IN` for the following jobs:
 
 * [deploy](/platform/workflow/job/deploy)
 * [runSh](/platform/workflow/job/runSh)
 
 ## Default Environment Variables
-Whenever `cluster` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `cluster` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `cluster`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `cluster`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_POINTER\_REGION 				| Region defined in the pointer. Available if the integration is AWS or Google |
-| `<NAME>`\_POINTER\_CLUSTERNAME 			| ClusterName defined in the pointer. Available if the integration is Google |
-| `<NAME>`\_POINTER\_NAMESPACE 			| Namespace defined in the pointer. Available if the integration is Google |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_POINTER\_REGION 				| Region defined in the pointer. Available if the integration is AWS or Google. |
+| `<NAME>`\_POINTER\_CLUSTERNAME 			| ClusterName defined in the pointer. Available if the integration is Google. |
+| `<NAME>`\_POINTER\_NAMESPACE 			| Namespace defined in the pointer. Available if the integration is Google. |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
-| `<NAME>`\_VERSIONNAME						| versionName of the version of the resource being used. |
+| `<NAME>`\_VERSIONNAME						| The versionName of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [manifest Job](/platform/workflow/job/manifest)

--- a/sources/platform/workflow/resource/dockeroptions.md
+++ b/sources/platform/workflow/resource/dockeroptions.md
@@ -4,7 +4,9 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # dockerOptions
-This resource type is used to add a list of docker options that can be appended to a docker image. This resource on its own does not mean anything unless used in conjunction with an [image resource](/platform/workflow/resource/image/). A `dockerOptions` resource can be an `IN` resource for [a manifest job](/platformworkflow/job/manifest/), or for a [deploy job](/platformworkflow/job/deploy/).
+This resource type is used to add a list of docker options that can be appended to a docker image. This resource on its own does not mean anything unless used in conjunction with an [image resource](/platform/workflow/resource/image/) or a [manifest job](/platform/workflow/job/manifest/). A `dockerOptions` resource can be an `IN` resource for a [manifest job](/platform/workflow/job/manifest/), or for a [deploy job](/platform/workflow/job/deploy/).
+
+If you do not provide a dockerOptions resource to a manifest job, it will set memory to 400mb by default. No other default settings will be used.
 
 ## Configuration reference
 
@@ -83,7 +85,7 @@ resources:
         - <string>
       cGroupParent: <string>                    # Optional
       memoryReservation: <number>               # This should be given in MB
-      pid : <string>                            # Optional
+      pid: <string>                            # Optional
       network: <string>                         # Optional
       devices:                                  # For DCL
         - <string>
@@ -93,9 +95,9 @@ resources:
           cGroupPermissions: <string>
 ```
 
-This will create a resource of type `dockerOptions`. You can include any settings shown above that you want as part of your `dockerOptions`. All settings are optional. Read below for a description and format of all settings.
+This will create a resource of type `dockerOptions`. You can include any settings shown above that you want as part of your `dockerOptions`. All settings are optional. Read below for a description and the format of each setting.
 
-For a table showing the mapping of each setting to a setting in your Container Service, read the [mapping dockerOptions to your Container Service section](#mappingDockerOptions).
+For a table showing the mapping of each setting to a setting in your Container Service, read [mapping dockerOptions to your Container Service](#mappingDockerOptions).
 
 ```
 - name: <string>
@@ -116,7 +118,7 @@ For a table showing the mapping of each setting to a setting in your Container S
 ```
    memory: <number>
 ```
-`memory` is the amount of memory in mebibytes allocated to the container. It is set in megabytes and is an integer. It defaults to 400MiB if not specified.
+`memory` is the amount of memory in mebibytes allocated to the container. It is an integer and defaults to 400MiB if not specified.
 
 
 ```
@@ -137,7 +139,7 @@ For a table showing the mapping of each setting to a setting in your Container S
 ```
 `links` allows containers to communicate with each other without the need for port mappings. The format for this is `"<container name>:<alias>"`, e.g. "shippabledb:db".
 
-This setting maps to Links in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a>  of the Docker Remote API and the --link option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to Links in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a>  of the Docker Remote API and the --link option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     volumes:
@@ -146,7 +148,7 @@ This setting maps to Links in the <a href="https://docs.docker.com/platform/api/
 ```
 `volumes` configures mount points for data volumes in your container. This is a list of objects, format for each object being `"<source volume>:<container path>:<options>"`. The source volume is a string specifying the name of the volume to mount; the container path is a string specifying the path on the container where volume should be mounted. Options can be set to `rw` if you want the container to be able to write to the volume, and `ro` if you want the container to have read-only access. Default setting is `rw`.
 
-This setting maps to Volumes in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --volume option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to Volumes in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --volume option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     logConfig:
@@ -157,7 +159,7 @@ This setting maps to Volumes in the <a href="https://docs.docker.com/platform/ap
 ```
 `logConfig` specifies the log configuration of the container. By default, containers use the same logging driver that the Docker daemon uses. To override this and specify a different logging driver, include this setting in your dockerOptions. The available logging drivers depend on your Container Service. For example, `type` can be set to `"syslog"` and you can specify options using key value pairs.
 
-This setting maps to LogConfig in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --log-driver option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to LogConfig in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --log-driver option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     entryPoint:
@@ -166,7 +168,7 @@ This setting maps to LogConfig in the <a href="https://docs.docker.com/platform/
 ```
 `entryPoint` specifies the entry point(s) passed to the container. It is an array of strings.
 
-This setting maps to Entrypoint in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --entrypoint option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>. Read more information about the Docker ENTRYPOINT parameter at <a href="https://docs.docker.com/platform/builder/#entrypoint" target="_blank">https://docs.docker.com/platform/builder/#entrypoint</a>.
+This setting maps to Entrypoint in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --entrypoint option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>. Read more information about the Docker ENTRYPOINT parameter at <a href="https://docs.docker.com/engine/reference/builder/#entrypoint" target="_blank">https://docs.docker.com/engine/reference/builder/#entrypoint</a>.
 
 ```
     cmd:
@@ -175,7 +177,7 @@ This setting maps to Entrypoint in the <a href="https://docs.docker.com/platform
 ```
 `cmd` specifies the command(s) is passed to the container.
 
-This setting maps to Cmd in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the COMMAND parameter to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>. For more information about the Docker CMD parameter, go to <a href="https://docs.docker.com/platform/builder/#cmd" target="_blank">https://docs.docker.com/platform/builder/#cmd</a>.
+This setting maps to Cmd in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the COMMAND parameter to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>. For more information about the Docker CMD parameter, go to <a href="https://docs.docker.com/engine/reference/builder/#cmd" target="_blank">https://docs.docker.com/engine/reference/builder/#cmd</a>.
 
 NOTE: Multiple commands provided on a single line are not parsed successfully. Splitting each command on separate lines will correctly create and pass the CMD array.
 
@@ -197,14 +199,14 @@ split each command on a separate line as shown below:
 ```
 `workingDir` specifies the working directory where commands are run inside the container.
 
-This setting maps to WorkingDir in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --workdir option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to WorkingDir in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --workdir option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     privileged: <boolean>
 ```
 `privileged` specifies the level of access the container has to the host container instance. When set to `true`, the container has elevated privileges on the host container instance, similar to the *root* user.
 
-This setting maps to Privileged in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --privileged option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to Privileged in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --privileged option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     labels:
@@ -213,7 +215,7 @@ This setting maps to Privileged in the <a href="https://docs.docker.com/platform
 ```
 `labels` specifies a list of key/value pairs of labels to add to the container.
 
-This setting maps to Labels in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --label option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to Labels in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --label option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     volumesFrom:
@@ -223,7 +225,7 @@ This setting maps to Labels in the <a href="https://docs.docker.com/platform/api
 ```
 `volumesFrom` specifies the list of data volumes to mount from another container.
 
-This setting maps to VolumesFrom in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --volumes-from option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>. `options` can be `rw` if you want the container to be able to write to the volume, and `ro` if you want the container to have read-only access. Default setting is `rw`.
+This setting maps to VolumesFrom in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --volumes-from option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>. `options` can be `rw` if you want the container to be able to write to the volume, and `ro` if you want the container to have read-only access. Default setting is `rw`.
 
 ```
     ulimits:
@@ -236,7 +238,7 @@ This setting maps to VolumesFrom in the <a href="https://docs.docker.com/platfor
 ```
 `ulimits` specifies a list of ulimits to be set in the container.
 
-This setting maps to Ulimits in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --ulimit option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to Ulimits in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --ulimit option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     dnsServers:
@@ -245,7 +247,7 @@ This setting maps to Ulimits in the <a href="https://docs.docker.com/platform/ap
 ```
 `dnsServers` specifies a list of DNS servers that are presented to the container.
 
-This setting maps to Dns in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --dns option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to Dns in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --dns option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 
 ```
@@ -254,29 +256,27 @@ This setting maps to Dns in the <a href="https://docs.docker.com/platform/api/do
 ```
 `dnsSearch` specifies a list of DNS search domains that are presented to the container.
 
-This setting maps to DnsSearch in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --dns-search option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
+This setting maps to DnsSearch in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --dns-search option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 ```
     user: <string>
 ```
 `user` specifies the user name to be uses inside the container.
 
-This setting maps to User in the <a href="https://docs.docker.com/platform/api/docker_remote_api_v1.19/#create-a-container" target="_blank">create a container section</a> of the Docker Remote API and the --user option to <a href="https://docs.docker.com/engine/platform/run/" target="_blank">docker run</a>.
-
-If you do not provide a dockerOptions resource to a manifest job, it will set memory to 400mb by default. No other default settings will be used.
+This setting maps to User in the <a href="https://docs.docker.com/engine/api/v1.27/#operation/ContainerCreate" target="_blank">create a container section</a> of the Docker Remote API and the --user option to <a href="https://docs.docker.com/engine/reference/run/" target="_blank">docker run</a>.
 
 
 <a name="mappingDockerOptions"></a>
 ##Mapping dockerOptions to your Container Service
-Even though `dockerOptions` supports a wide variety of configurations, you can only use options that are relevant for your Container Service. The table below maps our tags to settings in Amazon EC2 Container Service (ECS), Kubernetes, Google Container Engine (GKE), Joyent Triton Public Cloud, Docker Cloud (DCL), and Docker Datacenter (DDC).
+Even though `dockerOptions` supports a wide variety of configurations, you can only use options that are relevant for your Container Service. The table below maps our tags to settings in Amazon EC2 Container Service (ECS), Kubernetes, Google Container Engine (GKE), Joyent Triton Public Cloud, Docker Cloud (DCL), Docker Datacenter (DDC), and Azure DC/OS.
 
 There are two levels of mapping in dockerOptions.
 
-- __Container Level__ : The docker options, which will be mapped to container level fields in the configuration of the container service. Example: Fields present inside [containerDefinitions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions) of [taskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) in ECS.
+- __Container Level__: The docker options that will be mapped to container level fields in the configuration of the container service. Example: Fields present inside [containerDefinitions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions) of [taskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) in ECS.
 
-- __Top level__ : The docker options, which will be mapped to fields that are common to one or more containers in the configuration of the container service. Example: Fields present at root level of [taskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) will be top level options and are common to all containers in [containerDefinitions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions).
+- __Top Level__: The docker options that will be mapped to fields that are common to one or more containers in the configuration of the container service. Example: Fields present at root level of [taskDefinition](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) will be top level options and are common to all containers in [containerDefinitions](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions).
 
-The prefix `TOP LEVEL ->` denotes that the field will be mapped to one of the top level docker options metioned in  [Provider specific options](workflow/resource/dockeroptions/#provider-specific-options).
+The prefix `TOP LEVEL ->` denotes that the field will be mapped to one of the top level docker options mentioned in  [Provider specific options](/platform/workflow/resource/dockeroptions/#provider-specific-options).
 
 | Shippable Tag                     | Amazon ECS                       | Kubernetes                        | GKE                        | TRITON [Remote API v1.21] | DCL             | DDC [ Remote API v1.24] | Azure DC/OS |
 |-------------------------------|----------------------------------|----------------------------|----------------------------|---------------------------|-----------------|-------------------------|---------------------|
@@ -325,11 +325,11 @@ The prefix `TOP LEVEL ->` denotes that the field will be mapped to one of the to
 Here are links to docs for each Container Service:
 
 * [Amazon ECS](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html)
-* [Kubernetes](https://kubernetes.io/docs/platform/)
+* [Kubernetes](https://kubernetes.io/docs/reference/)
 * [Google Container Engine (GKE)](https://cloud.google.com/container-engine/docs/apis)
-* [Joyent Triton](https://docs.docker.com/v1.9/engine/platform/api/docker_remote_api_v1.18/)
+* [Joyent Triton](https://docs.docker.com/engine/api/v1.27/)
 * [Docker Cloud](https://docs.docker.com/apidocs/docker-cloud/#service)
-* [Docker Datacenter](https://docs.docker.com/v1.9/engine/platform/api/docker_remote_api_v1.18/)
+* [Docker Datacenter](https://docs.docker.com/engine/api/v1.27/)
 * [Azure DC/OS](https://mesosphere.github.io/marathon/docs/native-docker.html)
 
 ## Provider specific options
@@ -337,7 +337,7 @@ Many options listed above are shared across all providers. For example, every pr
 
 ### Amazon ECS
 
-Container level docker options: These fields map to each objects inside `containerDefinitions` of `taskDefinition`.
+Container level docker options: These fields map to each object inside `containerDefinitions` of `taskDefinition`.
 ```
 resources:
   - name: <string>
@@ -346,7 +346,7 @@ resources:
       essential: boolean
 ```
 
-Top level docker options: There are two top levels for Amazon ECS i.e. `service` and `taskDefinition`. Please refer following yml to find the possible options, that can be given under them.
+Top level docker options: There are two top levels for Amazon ECS, i.e., `service` and `taskDefinition`. Please refer the following yml to find the possible options, that can be given under them.
 ```
   resources:
   - name: <string>
@@ -446,7 +446,7 @@ resources:
 
 ### Google Container Engine
 
-Top level docker options: Only one top level is currently supported for Google Container Engine i.e. pod. In future, Shippable might support more top level objects like `replication controller`, `namespace`. Please open a [support ticket](https://github.com/Shippable/support), if you are in need of specific top level option.
+Top level docker options: Only one top level, `pod`, is currently supported for Google Container Engine. In future, Shippable might support more top level objects like `replication controller` or `namespace`. Please open a [support ticket](https://github.com/Shippable/support), if you need a specific top level option.
 ```
 resources:
   - name: <string>
@@ -549,7 +549,7 @@ None at this time
 ### AZURE DC/OS
 App level docker options:
 
-Parameters accept all the arbitrary docker options according to [mesosphere docs](https://mesosphere.github.io/marathon/docs/native-docker.html#privileged-mode-and-arbitrary-docker-options)
+Parameters accept all the arbitrary docker options according to the [mesosphere documentation](https://mesosphere.github.io/marathon/docs/native-docker.html#privileged-mode-and-arbitrary-docker-options)
 
 ```
 resources:
@@ -569,7 +569,7 @@ resources:
 
 For example, if you want to use different settings for your service in Test and Production environments, you can do so by overriding one or more settings in the resource.
 
-<img src="../../images/platform/resources/overrideDockerOptions.png" alt="Docker Options">
+<img src="/images/platform/resources/overrideDockerOptions.png" alt="Docker Options">
 
 In the picture above, `deploy-test` takes `dockerOptions-1` as an input. After testing, a release is created with the `release` job. This triggers production deployment with the `deploy-prod` job, which takes `dockerOptions-2` as an input. For this production deployment, we will use a superset of settings from `dockerOptions-1` and `dockerOptions-2`, with values for any common settings being chosen from `dockerOptions-2`.
 
@@ -577,4 +577,4 @@ In the picture above, `deploy-test` takes `dockerOptions-1` as an input. After t
 
 When anything in `dockerOptions` changes, a new version of the resource is created. However, this does not automatically trigger subsequent portions of the pipeline since we have no way of knowing if your code commit changing dockerOptions also changed something else in the pipeline. Triggering dependent jobs automatically might lead to unexpected behavior in this case.
 
-To trigger the rest of the workflow, you will need to manually trigger any jobs that have this resource as an input. You can do this through the UI by right clicking on the dependent job and clicking on `Run`, or by updating an input [trigger resource](shippable-triggers-yml/)
+To trigger the rest of the workflow, you will need to manually trigger any jobs that have this resource as an input. You can do this through the UI by right clicking on the dependent job and clicking on `Run`, or by updating an input [trigger resource](/platform/tutorial/workflow/shippable-triggers-yml/).

--- a/sources/platform/workflow/resource/file.md
+++ b/sources/platform/workflow/resource/file.md
@@ -4,68 +4,66 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # file
-`file` resource is a pointer to a file on an external file share. When used as an IN to a job, the file is downloaded and available to be used.
+`file` resource is a pointer to a file on an external file share. When used as an `IN` to a job, the file is downloaded and available to be used.
 
 You can create a `file` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			file
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           file
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `file`
 
-* **`integration`** -- name of the integration. Currently supported integrations are
-	* [JFrog](/platform/integration/jfrog-artifactory)
+* **`integration`** -- name of the subscription integration. Currently supported integration types are:
+	* [JFrog Artifactory](/platform/integration/jfrog-artifactory)
 
-* **`pointer`** -- is an object which contains integration specific properties
-	* For empty integration
+* **`pointer`** -- is an object that contains integration specific properties
+	* Without an integration:
 
-	```
-	    pointer:
-	      sourceName: <points to publicly accessible file URI>
-	```
-	* For JFrog integration
+	        pointer:
+	          sourceName: <points to publicly accessible file URI>
 
-	```
-	    pointer:
-	      sourceName: <in format "repositoryName/path" of a artifactory respository file>
-	```
+	* With a JFrog Artifactory integration:
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+	        pointer:
+	          sourceName: <"repositoryName/path" of an Artifactory repository file>
+
+## Used in Jobs
+This resource is used as an `IN` for the following jobs:
 
 * [deploy](/platform/workflow/job/deploy)
 * [runSh](/platform/workflow/job/runsh)
 * [manifest](/platform/workflow/job/manifest)
 
 ## Default Environment Variables
-Whenever `file` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `file` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
+
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `file`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `file`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
-| `<NAME>`\_VERSIONNAME						| versionName of the version of the resource being used. |
+| `<NAME>`\_VERSIONNAME						| The versionName of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/gitrepo.md
+++ b/sources/platform/workflow/resource/gitrepo.md
@@ -10,114 +10,113 @@ You can create a `gitRepo` resource by [adding](/platform/tutorial/workflow/howt
 
 ```
 resources:
-  - name: 			<string>
-    type: 			cliConfig
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           cliConfig
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `gitRepo`
 
-* **`integration`** -- name of the integration. Currently supported integrations are
+* **`integration`** -- name of the subscription integration. Currently supported integration types are:
 	* [Bitbucket](/platform/integration/bitbucket)
-	* [Bitbucket Server](/platform/integration/bitbucket-server)
+	* Bitbucket Server (Shippable Server only)
 	* [GitHub](/platform/integration/github)
-	* [Gitlab/GitlabServer](/platform/integration/gitlab)
+	* [GitLab](/platform/integration/gitlab)
 
-* **`pointer`** -- is an object which contains integration specific properties
+* **`pointer`** -- is an object that contains integration specific properties
 
-```
-  pointer:
-    sourceName: 			<string>
-    branch: 				<string>
-    branches:
-      except:
-        - <branch name>		<string>
-        - <branch name>		<string>
-      only:
-        - <branch name>		<string>
-        - <branch name>		<string>
-    tags:
-      except:
-        - <tag name>		<string>
-        - <tag name>		<string>
-      only:
-        - <tag name>		<string>
-        - <tag name>		<string>
-	buildOnCommit: 			<Boolean>
-	buildOnPullRequest: 	<Boolean>
-	buildOnRelease: 		<Boolean>
-	buildOnTagPush: 		<Boolean>
-```
+          pointer:
+            sourceName:             <string>
+            branch:                 <string>
+            branches:
+              except:
+                - <branch name>
+                - <branch name>
+              only:
+                - <branch name>
+                - <branch name>
+            tags:
+              except:
+                - <tag name>
+                - <tag name>
+              only:
+                - <tag name>
+                - <tag name>
+            buildOnCommit:          <Boolean>
+            buildOnPullRequest:     <Boolean>
+            buildOnRelease:         <Boolean>
+            buildOnTagPush:         <Boolean>
 
-* Detailed explation of the pointer properties
-	* `sourceName` -- (required) is the fully qualified name of the repository in the format 88org/repo**
-    * `branch` -- (optional) specifies specific branch name which this resource represents. If not set, all branches trigger a new version. Cannot be set if `branches` property is used
-    * `branches` -- (optional) works like the `branch` but allows to use it for a collection of branches. Cannot be used if `branch` is used. Wildcards can used in names. e.g. feat-*
+* Detailed explation of the pointer properties:
+	* `sourceName` -- (required) is the fully qualified name of the repository in the format **org/repo**
+    * `branch` -- (optional) specifies specific branch name that this resource represents. If not set, all branches trigger a new version. Cannot be set if `branches` property is used
+    * `branches` -- (optional) works like the `branch` but allows to use it for a collection of branches. Cannot be used if `branch` is used. Wildcards can used in names, e.g., feat-*
     	* `except` -- (optional) Can be used to exclude a collection of branches
     	* `only` -- (optional) Can be used to include only a collection of specific branches
     * `tags` -- (optional) used to specify a collection of tags and releases upon which a new version is created
     	* `except` -- (optional) Can be used to exclude a collection of tags or releases
     	* `only` -- (optional) Can be used to include only a collection of specific tags or releases
-    * `buildOnCommit` -- (default is true) used to control whether the resource wil be updated for commit webhooks
-    * `buildOnPullRequest` -- (default is false) used to control whether the resource wil be updated for pull-request webhooks
-    * `buildOnRelease` -- (default is false) used to control whether the resource wil be updated for release webhooks    
-    * `buildOnTagPush` -- (default is false) used to control whether the resource wil be updated for tag webhooks
+    * `buildOnCommit` -- (default is true) used to control whether the resource will be updated for commit webhooks
+    * `buildOnPullRequest` -- (default is false) used to control whether the resource will be updated for pull request webhooks
+    * `buildOnRelease` -- (default is false) used to control whether the resource will be updated for release webhooks    
+    * `buildOnTagPush` -- (default is false) used to control whether the resource will be updated for tag webhooks
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+## Used in Jobs
+This resource is used as an `IN` for the following jobs:
 
 * [runSh](/platform/workflow/job/runsh)
 * [runCI](/platform/workflow/job/runci)
 
 ## Default Environment Variables
-Whenever `gitRepo` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `gitRepo` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
+
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `gitRepo`|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `gitRepo`. |
 | `<NAME>`\_BASE\_BRANCH       			| If the version was created for a pull request, this is the name of the base branch into which the pull request changes will be merged. |
 | `<NAME>`\_BRANCH            			| When the version was created for a commit, this is the name of branch on which the commit occurred. If it was created for a pull request, this is the base branch. |
 | `<NAME>`\_COMMIT            			| SHA of the commit of the version being used. |
 | `<NAME>`\_COMMIT\_MESSAGE    			| Commit message of the version being used. |
 | `<NAME>`\_COMMITTER         			| Name of the committer for the SHA being used. |
-| `<NAME>`\_GIT\_TAG\_NAME      			| If a Tag Name was present in the current version, Supported only if the Integration is GitHub.|
+| `<NAME>`\_GIT\_TAG\_NAME      			| If a tag name was present in the current version, this will be the tag name. Supported only if the integration is GitHub.|
 | `<NAME>`\_HEAD\_BRANCH       			| If the version in context is a pull requests, then this is the name of the branch the pull request was opened from. |
 | `<NAME>`\_HTTPS\_URL       				| The HTTPS URL for the Git repository. |
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
-| `<NAME>`\_IS\_GIT\_TAG        			| Set to `TRUE` if the version in context is a git tag based build. Supported only if the Integration is GitHub. |
-| `<NAME>`\_IS\_RELEASE        			| Set to `TRUE` if the version in context is a git release based build. Supported only if the Integration is GitHub. |
-| `<NAME>`\_KEYPATH           			| Path to the ssh keyfile associated with the gitRepo. This is the key that is used to clone the repo |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
+| `<NAME>`\_IS\_GIT\_TAG        			| Set to `TRUE` if the version in context is a git tag based build. Supported only if the integration is GitHub. |
+| `<NAME>`\_IS\_RELEASE        			| Set to `TRUE` if the version in context is a git release based build. Supported only if the integration is GitHub. |
+| `<NAME>`\_KEYPATH           			| Path to the ssh keyfile associated with the gitRepo. This is the key that is used to clone the repo. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_POINTER_BRANCH    			| Branch if defined in the pointer |
-| `<NAME>`\_POINTER\_BRANCHES\_EXCEPT\_0 | Branches except collection if defined in the pointer. 0 throug N elements |
-| `<NAME>`\_POINTER\_BRANCHES\_ONLY\_0 | Branches only collection if defined in the pointer. 0 throug N elements |
-| `<NAME>`\_POINTER\_TAGS\_EXCEPT\_0 	| Tags except collection if defined in the pointer. 0 throug N elements |
-| `<NAME>`\_POINTER\_TAGS\_ONLY\_0 		| Tags only collection if definedin the pointer. 0 throug N elements |
-| `<NAME>`\_POINTER_BUILDONCOMMIT			| TRUE or FALSE, default is TRUE, if not defined in the pointer |
-| `<NAME>`\_POINTER_BUILDONPULLREQUEST	| TRUE or FALSE, default is FALSE, if not defined in the pointer |
-| `<NAME>`\_POINTER_BUILDONRELEASE		| TRUE or FALSE, default is FALSE, if not defined in the pointer |
-| `<NAME>`\_POINTER_BUILDONTAGPUSH		| TRUE or FALSE, default is FALSE, if not defined in the pointer |
+| `<NAME>`\_POINTER_BRANCH    			| Branch if defined in the pointer. |
+| `<NAME>`\_POINTER\_BRANCHES\_EXCEPT\_0 | Branches except collection if defined in the pointer. 0 through N elements |
+| `<NAME>`\_POINTER\_BRANCHES\_ONLY\_0 | Branches only collection if defined in the pointer. 0 through N elements. |
+| `<NAME>`\_POINTER\_TAGS\_EXCEPT\_0 	| Tags except collection if defined in the pointer. 0 through N elements. |
+| `<NAME>`\_POINTER\_TAGS\_ONLY\_0 		| Tags only collection if defined in the pointer. 0 through N elements. |
+| `<NAME>`\_POINTER_BUILDONCOMMIT			| TRUE or FALSE, default is TRUE, if not defined in the pointer. |
+| `<NAME>`\_POINTER_BUILDONPULLREQUEST	| TRUE or FALSE, default is FALSE, if not defined in the pointer. |
+| `<NAME>`\_POINTER_BUILDONRELEASE		| TRUE or FALSE, default is FALSE, if not defined in the pointer. |
+| `<NAME>`\_POINTER_BUILDONTAGPUSH		| TRUE or FALSE, default is FALSE, if not defined in the pointer. |
 | `<NAME>`\_PULL\_REQUEST      			| Pull request number if the version was created for a pull request. If not, this will be set to false. |
-| `<NAME>`\_RELEASE|_NAME      			| Name of the release if the version in context is a git release based build. Supported only if the Integration is GitHub. |
-| `<NAME>`\_RELEASED\_AT       			| Timestamp of the release if the version in context is a git release based build. Supported only if the Integration is GitHub. |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
-| `<NAME>`\_SSH|_URL      					| The SSH URL for the Git repository. |
+| `<NAME>`\_RELEASE_NAME      			| Name of the release if the version in context is a git release based build. Supported only if the integration is GitHub. |
+| `<NAME>`\_RELEASED\_AT       			| Timestamp of the release if the version in context is a git release based build. Supported only if the integration is GitHub. |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
+| `<NAME>`\_SSH_URL      					| The SSH URL for the Git repository. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNAME   					| The commitSHA of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/image.md
+++ b/sources/platform/workflow/resource/image.md
@@ -4,23 +4,23 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # image
-`image` resource is used to add a reference to a docker image to your pipeline.
+`image` resource is used to add a reference to a Docker image to your pipeline.
 
 You can create a `image` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			image
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           image
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `image`
 
-* **`integration`** -- name of the integration. Currently supported integrations are
+* **`integration`** -- name of the subscription integration. Currently supported integration types are
 	- [Amazon Elastic Container Registry (ECR)](/platform/integration/aws-ecr)
 	- [Docker Hub](/platform/integration/docker-hub)
 	- [Docker Trusted Registry](/platform/integration/docker-trusted-registry)
@@ -29,50 +29,46 @@ resources:
 	- [JFrog Artifactory](/platform/integration/jfrog-artifactory)
 	- [Quay.io](/platform/integration/quay)
 
-* **`pointer`** -- is an object which contains integration specific properties
+* **`pointer`** -- is an object that contains integration specific properties
 
-```
-  pointer:
-    sourceName: < Fully Qualified Name of the image, can be just repo/image in case of Docker Hub
-    isPull: <boolean - default is false, but if true, then then image is pulled into your runSh runntime>
-```
-* **`seed`** -- is an object which contains initial version properties
+          pointer:
+            sourceName: <fully qualified image name, can be just repo/image for Docker Hub>
 
-```
-  seed:
-    versionName: <Name of the image tag>
-```
+* **`seed`** -- is an object that contains initial version properties
 
-## Used in JOBs
+          seed:
+            versionName: <image tag>
+
+## Used in Jobs
 This resource is used as an IN for the following jobs
 
 * [deploy](/platform/workflow/job/deploy)
-* [runSh](/platform/workflow/job/runSh)
+* [runSh](/platform/workflow/job/runsh)
 * [manifest](/platform/workflow/job/manifest)
 
 ## Default Environment Variables
-Whenever `image` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `image` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `image`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `image`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
-| `<NAME>`\_SEED\_VERSIONNAME 			| VersionName defined in the seed |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
+| `<NAME>`\_SEED\_VERSIONNAME 			| VersionName defined in the seed. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
-| `<NAME>`\_VERSIONNAME						| versionName which is the tag of the version of the resource being used. |
+| `<NAME>`\_VERSIONNAME						| The versionName, which is the image tag for the version used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/integration.md
+++ b/sources/platform/workflow/resource/integration.md
@@ -4,43 +4,41 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # integration
-`integration` resource is used to represent credentials that has been encrypted using Shippable Integrations.
+`integration` resource is used to represent credentials that have been encrypted using Shippable Integrations.
 
 You can create a `integration` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 
 ```
 resources:
-  - name: 			<string>
-    type: 			integration
-    integration: 	<string>
+  - name:           <string>
+    type:           integration
+    integration:    <string>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `integration`
 
-* **`integration`** -- name of the integration. All [Shippable Integrations](/platform/integration/overview/) can be used here
+* **`integration`** -- name of the subscription integration. All [Shippable Integrations](/platform/integration/overview/) can be used here
 
-* `name` should be an easy to remember text string. This will appear in the visualization of this resource in the SPOG view. It is also used to refer to this resource in the `shippable.jobs.yml`. If you have spaces in your name, you'll need to surround the value with quotes, however, as a best practice we recommend not including spaces in your names.
-
-## Used in JOBs
+## Used in Jobs
 This resource is used as an IN for the following jobs
 
 * [runSh](/platform/workflow/job/runsh)
 * [runCI](/platform/workflow/job/runci)
 
 ## Default Environment Variables
-Whenever `integration` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `integration` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `integration`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `integration`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
@@ -48,19 +46,19 @@ Whenever `integration` is used as an `IN` or `OUT` into a Job that can execute u
 
 **Some special cases depending on the `integration` used**
 
-* If the integration of type [Key-Value pair](/platform/integration/key-value), the key-values are exported as it is without adding `RESOURCENAME_INTEGRATION_` in the key name. They act like [params](/platform/integration/params) resource, but in this case they are stored encrypted for security reasons
+* If the integration is of type [Key-Value pair](/platform/integration/key-value), the key-values are exported as-is without adding `RESOURCENAME_INTEGRATION_` in the key name. They act like [params](/platform/workflow/resource/params) resources, but are stored encrypted for security reasons.
 
-* If the integration of type [ssh-key](/platform/integration/key-ssh) or [pem-key](/platform/integration/key-pem) is used, the environment variable will mess up the key structure due to carriage returns. Hence the platform will extract the private key into a file and puts the location in the environment variable below
+* If the integration of type [ssh-key](/platform/integration/key-ssh) or [pem-key](/platform/integration/key-pem) is used, the environment variable will mess up the key structure due to carriage returns. Hence the platform will extract the private key into a file and puts the location in the environment variable below.
 
 	| Environment variable        |  Description                               |
 	|-----------------------------|--------------------------------------------|
-	| `<NAME>`\_KEYPATH      		| points directly to the private key file. |
+	| `<NAME>`\_KEYPATH           | points directly to the private key file.   |
 
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/loadbalancer.md
+++ b/sources/platform/workflow/resource/loadbalancer.md
@@ -10,112 +10,103 @@ You can create a `loadBalancer` resource by [adding](/platform/tutorial/workflow
 
 ```
 resources:
-  - name: 			<string>
-    type: 			loadBalancer
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           loadBalancer
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
-* **`type`** -- is set to `file`
+* **`type`** -- is set to `loadBalancer`
 
-* **`integration`** -- name of the integration. Currently supported integrations are
-	* [AWS](/platform/integration/aws)
+* **`integration`** -- name of the subscription integration. The integration is only used when this resource is an input for a [provision](/platform/workflow/job/provision) job. Currently supported integration types are:
 	* [Google Container Engine (GKE)](/platform/integration/gke)
 
-* **`pointer`** -- is an object which contains integration specific properties
-	* in case of [AWS Classic Load Balancers](https://aws.amazon.com/elasticloadbalancing/classicloadbalancer/)
+* **`pointer`** -- is an object that contains provider specific properties
+	* For [AWS Classic Load Balancers](https://aws.amazon.com/elasticloadbalancing/classicloadbalancer/),
 
-	```
-	    pointer:
-	      sourceName: 	<name of the Classic Load Balancer>
-	      method: 		classic
-	      role: 		<AWS IAM role used to update the Load Balancer>
+	        pointer:
+	          sourceName:   <name of the Classic Load Balancer>
+	          method:       classic
+	          role:         <AWS IAM role used to update the Load Balancer>
 
-	```
+	    Note: `role` is and optional setting and if set, the role should have trust relationship allowing "ecs.amazonaws.com", if this is left blank, Shippable will search for one that has the right level of trust automatically. If none is found, the job where this resource is used will fail.
 
-	Note: `role` is and optional setting and if set, the role should have trust relationship allowing "ecs.amazonaws.com", if this is left blank, shippable will search for one that has the right level of trust automatically. If none found, the job where this resource is used will fail
+	* For [AWS Application Load Balancers](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/),
 
-	* in case of [AWS Application Load Balancers](https://aws.amazon.com/elasticloadbalancing/applicationloadbalancer/)
+	        pointer:
+	          sourceName:   <name of the target group ARN>
+	          method:       application
+	          role:         <AWS IAM role used to update the Load Balancer>
 
-	```
-	    pointer:
-	      sourceName: 	<name of the target group ARN>
-	      method: 		application
-	      role: 		<AWS IAM role used to update the Load Balancer>
+	    Note: `role` is and optional setting and if set, the role should have trust relationship allowing "ecs.amazonaws.com", if this is left blank, Shippable will search for one that has the right level of trust automatically. If none is found, the job where this resource is used will fail.
 
-	```
-	Note: `role` is and optional setting and if set, the role should have trust relationship allowing "ecs.amazonaws.com", if this is left blank, shippable will search for one that has the right level of trust automatically. If none found, the job where this resource is used will fail
+	* For [GKE Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `deploy` jobs,
 
-	* in case of [GKE loadbalancers](https://kubernetes.io/docs/user-guide/services/) used in `deploy` jobs
+	        pointer:
+	          sourceName:   <name of GKE loadbalancer>
+	          method:       clusterIP | ExternalName | LoadBalancer | NodePort  #default is clusterIP
+	          namespace:    <name of the namespace where pod is deployed>       #optional
 
-	```
-	  pointer:
-		sourceName: 	<name of GKE loadbalancer>
-		method: 		clusterIP | ExternalName | LoadBalancer | NodePort  #default is clusterIP
-		namespace: 		<name of the namespace where pod is deployed on>    #optional
-	```
+	* For [GKE Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs,
 
-* in case of [GKE loadbalancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs
+	        pointer:
+	          sourceName:           <lowercase alphanumeric name only>
+	          method:               clusterIP | ExternalName | LoadBalancer | NodePort  #default is clusterIP
+	          namespace:            <name of the namespace where pod is deployed>       #optional
+	          clusterName:          <name of the GKE cluster>
+	          region:               <name of the region>
+	        version:
+	          ports:
+	            - name:             <string>
+	              protocol:         TCP | UDP #default TCP
+	              port:             <integer>
+	              targetPort:       <string>
+	              nodePort:         <integer>
+	          selector:
+	            <string> : <string>
+	          clusterIP:            None | "" | <string>
+	          externalIPs:
+	            - <string>
+	          sessionAffinity:      ClientIP | None
+	          loadBalancerIP:       <string>
+	          loadBalancerSourceRanges:
+	            - <string>
+	          externalName:         <string>
 
-	```
-	  pointer:
-		sourceName: 				<lowecase alphanumeric name only>
-		method: 					clusterIP | ExternalName | LoadBalancer | NodePort  #default is clusterIP
-		namespace: 					<name of the namespace where pod is deployed on>    #optional
-		clusterName: 				<name of the GKE cluster>
-		region: 					<name of the region>
-	  version:
-	    ports:
-	      - name: 					<string>
-	        protocol: 				TCP | UDP #default TCP
-	        port: 					<integer>
-	        targetPort: 			<string>
-	        nodePort: 				<integer>
-	    selector:
-	    							<string> : <string>
-	    clusterIP: 					None | "" | <string>
-	    externalIPs:
-	      - 						<string>
-	    sessionAffinity: 			ClientIP | None
-	    loadBalancerIP: 			<string>
-	    loadBalancerSourceRanges:
-	      - 						<string>
-	    externalName: 				<string>
-	```
-
-## Used in JOBs
-This resource is used as an IN for the following jobs
+## Used in Jobs
+This resource is used as an `IN` for the following jobs:
 
 * [deploy](/platform/workflow/job/deploy/)
 * [provision](/platform/workflow/job/provision/)
 
 ## Default Environment Variables
-Whenever `loadBalancer` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `loadBalancer` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
+
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `loadBalancer`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `loadBalancer`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_POINTER\_METHOD 				| Region defined in the pointer. Available if the integration is AWS or Google |
-| `<NAME>`\_POINTER\_ROLE 					| ClusterName defined in the pointer. Available if the integration is AWS |
-| `<NAME>`\_POINTER\_NAMESPACE 			| Namespace defined in the pointer. Available if the integration is Google |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_POINTER\_METHOD 				| Region defined in the pointer. Available if the integration is AWS or Google. |
+| `<NAME>`\_POINTER\_ROLE 					| ClusterName defined in the pointer. Available if the integration is AWS. |
+| `<NAME>`\_POINTER\_NAMESPACE 			| Namespace defined in the pointer. Available if the integration is Google. |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
-| `<NAME>`\_VERSIONNAME						| versionName of the version of the resource being used. |
+| `<NAME>`\_VERSIONNAME						| The versionName of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/notification.md
+++ b/sources/platform/workflow/resource/notification.md
@@ -4,17 +4,17 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # notification
-`notification` resource is used to connect DevOps Assembly Lines to notification providers of your choice. These are providers we currently support
+`notification` resource is used to connect DevOps Assembly Lines to notification providers of your choice. These are providers we currently support:
 
 * Email
 * Hipchat
 * IRC
 * Slack
 
-You can send notifications upon following events occuring in your workflow:
+You can send notifications upon the following events in your workflow:
 
-* Job starts (on_start)
-* Job is completed successfully (on_success)
+* Job started (on_start)
+* Job completed successfully (on_success)
 * Job failed (on_failure)
 * Job canceled (on_cancel)
 
@@ -22,90 +22,82 @@ You can create a `notification` resource by [adding](/platform/tutorial/workflow
 
 ```
 resources:
-  - name: 			<string>
-    type: 			notification
-    integration: 	<string>
-    pointer:		<object>
+  - name:           <string>
+    type:           notification
+    integration:    <string>
+    pointer:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `notification`
 
-* **`integration`** -- name of the integration. Currently supported integrations are
-	- [Email](integration/email)
-	- [HipChat](integration/hipchat)
-	- [IRC](integration/irc) - Not required
-	- [Slack](integration/slack) - Not required
+* **`integration`** -- name of the subscription integration. Currently supported providers are:
+	- Email - No integration required
+	- [HipChat](/platform/integration/hipchat)
+	- IRC - No integration required
+	- [Slack](/platform/integration/slack)
 
-* **`pointer`** -- is an object which contains integration specific properties
-	* in case of email
+* **`pointer`** -- is an object that contains provider specific properties
+	* For email,
 
-	```
-	  pointer:
-		method: email
-	     recipients:
-	       - "foo@foo.com"
-	       - "boo@boo.com"
-	```
+	        pointer:
+	          method: email
+	          recipients:
+	            - "foo@foo.com"
+	            - "boo@boo.com"
 
-	* in case of irc
+	* For IRC,
 
-	```
-	  pointer:
-		method: irc
-	     recipients:
-	       - "#beta"
-	       - "@botnot"
-	```
+	        pointer:
+	          method: irc
+	          recipients:
+	            - "#beta"
+	            - "@botnot"
 
-	* in case of slack
+	* For Slack
 
-	```
-	  integration: <slack integration name>
-	  pointer:
-	     recipients:
-	       - "#beta"
-	       - "@botnot"
-	```
-	* in case of hipchat
+	        integration: <slack integration name>
+	        pointer:
+	          recipients:
+	            - "#beta"
+	            - "@botnot"
 
-	```
-	  integration: <hipchat integration name>
-	  pointer:
-	     recipients:
-	       - "#beta"
-	       - "@botnot"
-	```
+	* For HipChat,
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+	        integration: <hipchat integration name>
+	        pointer:
+	          recipients:
+	            - "#beta"
+	            - "@botnot"
 
-* All job types
+## Used in Jobs
+This resource is used as a `NOTIFY` for all jobs.  For more information, see the [jobs overview](/platform/workflow/job/overview).
+
 
 ## Default Environment Variables
-Whenever `notification` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `notification` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `notification`|
-| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific Integration page|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `notification`. |
+| `<NAME>`\_INTEGRATION\_`<FIELDNAME>`	| Values from the integration that was used. More info on the specific integration page. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_POINTER\_METHOD 				| Method defined in the pointer. Available if set |
-| `<NAME>`\_POINTER\RECIPIENTS_0 			| Recipients array values 0 to N depending on how many of them are set |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_POINTER\_METHOD 				| Method defined in the pointer. Available if set. |
+| `<NAME>`\_POINTER\_RECIPIENTS_0 			| Recipients array values 0 to N depending on how many of them are set |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/overview.md
+++ b/sources/platform/workflow/resource/overview.md
@@ -7,34 +7,34 @@ page_description: List of supported resources
 page_keywords: Deploy multi containers, microservices, Continuous Integration, Continuous Deployment, CI/CD, testing, automation, pipelines, docker, lxc
 
 # Resources
-Resources are the basic building blocks of your pipelines. They typically contain information needed for [Jobs](/platform/workflow/job/overview/) to execute and sometimes they also are used to store information produced in a Job.
+Resources are the basic building blocks of your pipelines. They typically contain information needed for [jobs](/platform/workflow/job/overview/) to execute and sometimes they also are used to store information produced by a job.
 
-A key characteristic of resources is that they can be versioned and are immutable. A specific version of a resource is idempotent. i.e. it returns the same result every single time it is fetched. For e.g., git commit sha is always idempotent.
+A key characteristic of resources is that they can be versioned. A specific version of a resource is immutable, i.e. it returns the same result every single time it is fetched.
 
-They are predominantly used for the following reasons
+They are predominantly used for the following reasons:
 
-* Provide 3rd party secrets to the Job Runtime so that environment is configured with the right level of access rights to connect to external services. E.g. integration, cliConfig etc.
-* Supply information to set the context for the Jobs to execute. E.g. params, version etc.
-* A trigger to changes to the repo on the source control system. E.g. gitRepo, ciRepo, syncRepo
-* A trigger to execute a Job. E.g. time etc.
-* Act as an entitry to store stateful information produced during the execution of a Job. E.g. state, any resource to store key-value info
+* Provide 3rd party secrets to the job runtime so that environment is configured with the right level of access rights to connect to external services. E.g., integration or cliConfig resources can be used to provide credentials safely.
+* Supply information to set the context for the jobs to execute. E.g., params resources commonly store environment variables and version resources keep track of changing versions.
+* A trigger to changes to the repo on the source control system. E.g., a gitRepo, ciRepo, or syncRepo can trigger jobs whenever the source code is updated.
+* A trigger to execute a job. E.g., a time resource will trigger a job at set times.
+* Act as an entity to store stateful information produced during the execution of a job. E.g., state resources are commonly used to share information between jobs.  A job will also often update an image resource with a new tag.
 
 ## Definition
-Resources can be defined using declarative `YML` based code snippets as below
+Resources can be defined using declarative YML-based code snippets as below:
 
 ```
 resources:
-  - name: 				<string>
-    type: 				<resource type name>
-    integration: 		<string>
-    pointer:			<object>
-    seed:				<object>
-    version:			<object>
+  - name:               <string>
+    type:               <resource type name>
+    integration:        <string>
+    pointer:            <object>
+    seed:               <object>
+    version:            <object>
 ```
-For more information, read [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml)
+For more information, read [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml).
 
 ## Versions
-A key strength of a resource is that it is versioned. Any change made to the resource definition is stored as a new version with a unique identifier. This is critical if you want to be able to roll back, upgrades or pin the resource to a particular point of time. User-defined key-value pairs can be stored as part of resource versions.
+A key strength of a resource is that it is versioned. This is critical if you want to be able to roll back, upgrade, or pin the resource to a particular point of time. User-defined key-value pairs can be stored as part of resource versions.
 
 <a name="types"></a>
 ## Types
@@ -54,13 +54,13 @@ These are the types of resources that Shippable Workflow supports:
 | [notification](/platform/workflow/resource/notification/) | Resource to send alerts from the workflow |
 | [params](/platform/workflow/resource/params/) | Environment variables used to prime your job runtime |
 | [replicas](/platform/workflow/resource/replicas/) | Number of copies of the service to run |
-| [syncRepo](/platform/workflow/resource/gitrepo/) | Used to define DevOps Assembly Lines |
+| [syncRepo](/platform/workflow/resource/syncrepo/) | Used to define DevOps Assembly Lines |
 | [time](/platform/workflow/resource/time/) | Trigger a job at a specific day and time |
 | [version](/platform/workflow/resource/version/) | Semantic versions |
 
-If you need a resource that is not listed above, send us an email at [support@shippable.com](mailto:support@shippable.com)
+If you need a resource that is not listed above, send us an email at [support@shippable.com](mailto:support@shippable.com).
 
 ## Further Reading
 * [Working with Resources](/platform/tutorial/workflow/howto-crud-resource)
 * [Jobs](/platform/workflow/job/overview)
-* [Integrations](/platform/workflow/integration/overview)
+* [Integrations](/platform/integration/overview)

--- a/sources/platform/workflow/resource/params.md
+++ b/sources/platform/workflow/resource/params.md
@@ -4,34 +4,33 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # params
-`params` resource stores user defined key-value pairs. This can be then used to inject it into an Job Runtime environment where your DevOps activity runs or can be used to set environment variables of your deploy target (VMs or containers). There are two ways params resources can be used.
+`params` resource stores user defined key-value pairs. This can be then be injected into a job runtime environment where your DevOps activity runs or can set environment variables of your deploy target (VMs or containers).
 
 You can create a `params` resource by [adding](/platform/workflow/resource/resources-working-with#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			params
-    version:		<object>
+  - name:           <string>
+    type:           params
+    version:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `params`
 
-* **`version`** -- is an object which contains specific properties that applies to this resource. A new version is created anytime this section of the YML changes which might trigger your workflow depending on how you have set it up
+* **`version`** -- is an object that contains specific properties that apply to this resource. A new version is created any time this section of the YML changes.
 
-	```
-	  version:
-		params:
-		  KEY1: "value1"                     #requires at least one
-		  KEY2: "value2"                     #optional
-		  secure: <encrypted value>          #optional
-	```
-You can use secure variables to [encrypt](/ci/env-vars/#secure-variables) any key-value pairs that contain sensitive information you don't want to expose as plain text.
+          version:
+            params:
+              KEY1: "value1"                     #requires at least one
+              KEY2: "value2"                     #optional
+              secure: <encrypted value>          #optional
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+    You can use secure variables to [encrypt](/ci/env-vars/#secure-variables) any key-value pairs that contain sensitive information you don't want to expose as plain text.
+
+## Used in Jobs
+This resource is used as an `IN` for the following jobs
 
 * [runSh](/platform/workflow/job/runsh)
 * [runCI](/platform/workflow/job/runci)
@@ -39,27 +38,27 @@ This resource is used as an IN for the following jobs
 * [manifest](/platform/workflow/job/manifest)
 
 ## Default Environment Variables
-Whenever `params` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `params` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `params`|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `params`. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
-| KEY1    									| params section of the version is parsed and values are sourced. From above e.g. KEY1 will be set to `value1` |
-| KEY1    									| params section of the version is parsed and values are sourced. From above e.g. KEY2 will be set to `value2` |
+| KEY1    									| params section of the version is parsed and values are sourced. From above, e.g., KEY1 will be set to `value1`. |
+| KEY2    									| params section of the version is parsed and values are sourced. From above, e.g., KEY2 will be set to `value2`. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/replicas.md
+++ b/sources/platform/workflow/resource/replicas.md
@@ -4,55 +4,54 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # replicas
-`replicas` is a resource holds the number of instances of the container to deploy. It is used specifically to deploy Docker containers
+`replicas` is a resource that holds the number of instances of the container to deploy. It is used specifically to deploy Docker containers
 
 You can create a `replicas` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			replicas
-    version:		<object>
+  - name:           <string>
+    type:           replicas
+    version:        <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `replicas`
 
-* **`version`** -- is an object which contains specific properties that applies to this resource. Anytime this is changed in the YML a new version of the resource get created and it might trigger your workflow depending on how it is setup
+* **`version`** -- is an object that contains specific properties that apply to this resource. Any time this is changed in the YML, a new version of the resource will be created.
 
-	```
-	    version:
-	      count: 1			#integer value > 0
-	```
+	        version:
+	          count: 1          #integer value > 0
 
-## Used in JOBs
-This resource is used as an IN for the following jobs
+
+## Used in Jobs
+This resource is used as an `IN` for the following jobs:
 
 * [deploy jobs](/platform/workflow/job/deploy/)
 * [manifest jobs](/platform/workflow/job/manifest/)
 
 ## Default Environment Variables
-Whenever `replicas` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `replicas` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `replicas`|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `replicas`. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
-| `<NAME>`\_VERSION\_COUNT 				| count defined in the version |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
+| `<NAME>`\_VERSION\_COUNT 				| The count defined in the version. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/state.md
+++ b/sources/platform/workflow/resource/state.md
@@ -4,13 +4,13 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # state
-`state` resource is a special resource used to store data that can be shared between jobs. Shippable DevOps Assembly lines do not allow workflow that have circular dependency. There are certain situations where data needs to be passed back and forth between Jobs. For e.g. Terraform tasks create a state that needs to be persisted across the jobs. `state` resource was specifically designed to achieve circular dependencies in DevOps Assembly Lines.
+`state` resource is a special resource used to store data that can be shared between jobs. Shippable DevOps Assembly lines do not allow workflows that have circular dependencies. There are certain situations where data needs to be passed back and forth between jobs. For example, Terraform tasks create a state that needs to be persisted each time the job runs. `state` resource was specifically designed to achieve circular dependencies in DevOps Assembly Lines.
 
 You can create a `state` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
+  - name:           <string>
     type: 			state
 ```
 
@@ -18,30 +18,31 @@ resources:
 
 * **`type`** -- is set to `state`
 
-# Used in JOBs
-This resource is used as an IN or OUT in any of the jobs
+## Used in Jobs
+This resource is used as an `IN` or `OUT` of any of job.
 
 ## Default Environment Variables
-Whenever `state` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `state` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `state`|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `state`. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
+
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
-# Further Reading
+## Further Reading
 * [Jobs](/platform/workflow/job/overview)
 * [Resource](/platform/workflow/resource/overview)

--- a/sources/platform/workflow/resource/syncrepo.md
+++ b/sources/platform/workflow/resource/syncrepo.md
@@ -6,16 +6,16 @@ sub_sub_section: Resources
 # syncRepo
 `syncRepo` is a special resource in the sense that it is the only resource thats added from the UI. This the heart of Shippable DevOps Assembly Lines as it is the location where the definitions of your assembly lines are configured as code.
 
-At the core, it is a [gitRepo](/platform/workflow/resource/gitrepo) i.e. a source code repo which contains the workflow definitions namely. You can add a `syncRepo` by following these [instructions](/platform/tutorial/workflow/howto-crud-syncrepo)
+At the core, it is a [gitRepo](/platform/workflow/resource/gitrepo), i.e., a source code repo which contains the workflow definitions. You can add a `syncRepo` by following these [instructions](/platform/tutorial/workflow/howto-crud-syncrepo).
 
 
-This resource is a pointer to the source control repository containing the files that define your CI/CD workflow namely, [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml), [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml) & [shippable.triggers.yml](/platform/tutorial/workflow/shippable-triggers-yml)
+This resource is a pointer to the source control repository containing the files that define your CI/CD workflow, namely, [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml), [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml) and [shippable.triggers.yml](/platform/tutorial/workflow/shippable-triggers-yml).
 
-**Note:** Shippable only looks for the files in the root of the repo and looks for an exact match. Names like `shippable.resources.yml.example` are ignored. 
+**Note:** Shippable only looks for an exact match. Names like `shippable.resources.yml.example` are ignored.
 
-# Used in JOBs
-This resource is used as an IN to any Job if you choose to trigger something if the definition of your Assembly Lines change.
+## Used in Jobs
+This resource can be used as an `IN` to any job if you choose to trigger something whenever the definition of your Assembly Lines change.
 
-# Further Reading
+## Further Reading
 * [Jobs](/platform/workflow/job/overview)
 * [Resource](/platform/workflow/resource/overview)

--- a/sources/platform/workflow/resource/time.md
+++ b/sources/platform/workflow/resource/time.md
@@ -5,53 +5,52 @@ sub_sub_section: Resources
 
 
 # time
-`time` resource provides cron like functionality. It is used to to trigger a job in a cron like manner. This resource can be used used as an IN input for [any job](/platform/workflow/job/overview/). The timezone used for triggering jobs is UTC.
+`time` resource provides cron-like functionality. It is used to to trigger a job in a cron-like manner. This resource can be used used as an `IN` input for [any job](/platform/workflow/job/overview/). The timezone used for triggering jobs is UTC.
 
 You can create a `time` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			time
-    seed:			<object>
+  - name:           <string>
+    type:           time
+    seed:           <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `time`
 
-* **`seed`** -- is an object which contains specific properties that applies to this resource.
+* **`seed`** -- is an object which contains specific properties that apply to this resource
 
-	```
-		seed:
-		  interval: "*/2 * * * *"
-	```
-The `interval` follows the [standard Cron format](https://en.wikipedia.org/wiki/Cron). For example, the snippet above will trigger the job at 2 min intervals.
+	        seed:
+	          interval: "*/2 * * * *"
 
-## Used in JOBs
-This resource is used as an IN for any type of Job
+    The `interval` follows the [standard Cron format](https://en.wikipedia.org/wiki/Cron). For example, the snippet above will trigger the job at 2 min intervals.
+
+## Used in Jobs
+This resource is used as an `IN` for any type of job.
 
 ## Default Environment Variables
-Whenever `time` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `time` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `time`|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `time`. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_SEED\_INTERVAL 				| Interval defined in the seed section |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_SEED\_INTERVAL 				| Interval defined in the seed section. |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/workflow/resource/version.md
+++ b/sources/platform/workflow/resource/version.md
@@ -4,15 +4,15 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # version
-`version` resource is used to store <a href="http://www.semver.org/">the semantic version</a> numbers.
+`version` resource is used to store <a href="http://www.semver.org/">semantic version</a> numbers.
 
 You can create a `version` resource by [adding](/platform/tutorial/workflow/howto-crud-resource#adding) it to `shippable.resources.yml`
 
 ```
 resources:
-  - name: 			<string>
-    type: 			version
-    seed:			<object>
+  - name:           <string>
+    type:           version
+    seed:           <object>
 ```
 
 * **`name`** -- should be an easy to remember text string
@@ -21,42 +21,41 @@ resources:
 
 * **`seed`** -- is an object which contains specific properties that applies to this resource.
 
-	```
-		seed:
-		  versionName: "0.0.1"
-	```
-`versionName` is a string that represents a semantic version that is used as a starting point when used with a release job. You can also also use `0.0.0-alpha`, `0.0.0-beta` & `0.0.0-rc` formats.
+	        seed:
+	          versionName: "0.0.1"
 
-# Used in JOBs
-This resource is used as an IN for the following jobs
+    `versionName` is a string that represents a semantic version that is used as a starting point when used with a release job. You can also also use `0.0.0-alpha`, `0.0.0-beta` & `0.0.0-rc` formats.
+
+## Used in Jobs
+This resource is used as an `IN` for the following jobs:
 
 * [deploy](/platform/workflow/job/deploy)
 * [runSh](/platform/workflow/job/runsh)
 * [release](/platform/workflow/job/release)
 
 ## Default Environment Variables
-Whenever `version` is used as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+Whenever `version` is used as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when this resource is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_NAME 							| The name of the resource. |
 | `<NAME>`\_ID 								| The ID of the resource. |
-| `<NAME>`\_TYPE 							| The type of the resource. In this case `version`|
+| `<NAME>`\_TYPE 							| The type of the resource. In this case `version`. |
 | `<NAME>`\_OPERATION 						| The operation of the resource; either `IN` or `OUT`. |
 | `<NAME>`\_PATH 							| The directory containing files for the resource. |
-| `<NAME>`\_SEED\_VERSIONNAME				| VersionName defined in the seed section |
-| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer |
+| `<NAME>`\_SEED\_VERSIONNAME				| VersionName defined in the seed section. |
+| `<NAME>`\_SOURCENAME    					| SourceName defined in the pointer. |
 | `<NAME>`\_VERSIONID    					| The ID of the version of the resource being used. |
 | `<NAME>`\_VERSIONNAME						| versionName of the version of the resource being used. |
 | `<NAME>`\_VERSIONNUMBER 					| The number of the version of the resource being used. |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
-# Further Reading
+## Further Reading
 * [Jobs](/platform/workflow/job/overview)
 * [Resource](/platform/workflow/resource/overview)


### PR DESCRIPTION
Fixes broken links, formatting, some typos, and some grammar in the platform/workflow/resources section.  And removes some integrations listed as options where they aren't supported (AWS integration on a loadBalancer) and incorrect notes (where shippable.resources.yml may be in the repository and what a params update will trigger).