### PR TITLE
Fixes links in platform/integrations.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -251,10 +251,11 @@ pages:
       - Git Credential: platform/integration/git-credential.md
       - GitHub: platform/integration/github.md
       - GitHub Enterprise: platform/integration/github-enterprise.md
-      - Gitlab: platform/integration/gitlab.md
+      - GitLab: platform/integration/gitlab.md
+      - Google Cloud: platform/integration/gce.md
       - Google Container Engine: platform/integration/gke.md
       - Google Container Registry: platform/integration/gcr.md
-      - Hipchat: platform/integration/hipchat.md
+      - HipChat: platform/integration/hipchat.md
       - JFrog Artifactory: platform/integration/jfrog-artifactory.md
       - Joyent Triton: platform/integration/tripub.md
       - Key-value: platform/integration/key-value.md

--- a/sources/platform/integration/aws-ecr.md
+++ b/sources/platform/integration/aws-ecr.md
@@ -7,39 +7,38 @@ page_title: Amazon ECR integration
 
 Available under the Integration Family: **Hub**
 
-`Amazon ECR` Integration is used to connect Shippable DevOps Assembly Lines platform to Amazon Elastic Container Registry so that you can pull and push Docker images. 
+`Amazon ECR` Integration is used to connect Shippable DevOps Assembly Lines platform to Amazon Elastic Container Registry so that you can pull and push Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **AWS Access Key ID** -- Key ID to AWS IAM Account
 * **AWS Secret Access Key** -- Secret Key to AWS IAM Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Amazon ECR` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `Amazon ECR` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						         | Description        |
 | ------			 							         |----------------- |
 | `<NAME>`\_INTEGRATION\_AWS\_ACCESS\_KEY\_ID       | Access Key supplied in the integration |
-| `<NAME>`\_INTEGRATION\_AWS\_SECRET\_ACCESS\_KEY   | Access Key supplied in the integration |
+| `<NAME>`\_INTEGRATION\_AWS\_SECRET\_ACCESS\_KEY   | Secret Key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/aws-ecs.md
+++ b/sources/platform/integration/aws-ecs.md
@@ -7,25 +7,25 @@ page_title: Amazon ECS integration
 
 Available under the Integration Family: **deploy**
 
-`AWS IAM` Integration is used to connect Shippable DevOps Assembly Lines platform to Amazon Web Services to interact with it cloud services like ECR, ECS, EC2, S3 and so on.
+`AWS IAM` Integration is used to connect Shippable DevOps Assembly Lines platform to Amazon Web Services to interact with its cloud services like ECR, ECS, EC2, S3, and so on.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Assume Role ARN** -- Role to Assume when connecting to AWS
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `AWS` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `AWS` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						         | Description        |
 | ------			 							         |----------------- |
@@ -33,9 +33,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_ASSUMEROLEARN 	| ARN Role supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/aws.md
+++ b/sources/platform/integration/aws.md
@@ -7,7 +7,7 @@ page_title: Amazon ECR integration
 
 Available under the Integration Family: **deploy**
 
-`AWS` Integration is used to connect Shippable DevOps Assembly Lines platform to Amazon Web Services to interact with it cloud services like ECR, ECS, EC2, S3 and so on.
+`AWS` Integration is used to connect Shippable DevOps Assembly Lines platform to Amazon Web Services to interact with it cloud services like ECR, ECS, EC2, S3, and so on.
 
 You can create this from the integrations page. This is the information you would require to create this integration
 
@@ -16,16 +16,16 @@ You can create this from the integrations page. This is the information you woul
 * **AWS Secret Access Key** -- Secret Key to AWS IAM Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `AWS` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `AWS` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						         | Description        |
 | ------			 							         |----------------- |
@@ -33,9 +33,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_AWS\_SECRET\_ACCESS\_KEY   | Access Key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/azure-dcos.md
+++ b/sources/platform/integration/azure-dcos.md
@@ -7,25 +7,24 @@ page_title: Azure DC/OS integration
 
 Available under the Integration Family: **deploy**
 
-`Azure DC/OS` and `Azure Container Service` Integration is used to connect Shippable DevOps Assembly Lines platform to Azure Container Service to deploy Docker based applications
+`Azure DC/OS` and `Azure Container Service` integrations are used to connect Shippable DevOps Assembly Lines platform to Azure Container Service to deploy Docker based applications.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create either of these integrations from the integrations page. This is the information you would require to create one of these integrations:
 
 * **Name** -- friendly name for the integration
 * **Username** -- Username to login to Mesos master VM
 * **URL** -- DNS or IP address of Mesos master VM
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `AWS` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `Azure DC/OS` or `Azure Container Service` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description        |
 | ------			 							|----------------- |
@@ -33,9 +32,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_URL   			| URL supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/azure.md
+++ b/sources/platform/integration/azure.md
@@ -7,26 +7,25 @@ page_title: Azure DC/OS integration
 
 Available under the Integration Family: **generic**
 
-`Microsoft Azure` Integration is used to connect Shippable DevOps Assembly Lines platform to Microsoft Azure to manage cloud services and entities
+`Microsoft Azure` Integration is used to connect Shippable DevOps Assembly Lines platform to Microsoft Azure to manage cloud services and entities.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **Subscription ID** -- Subscription ID of Microsoft Azure subscription
+* **Subscription ID** -- Subscription ID of the Microsoft Azure subscription
 * **Username** -- Azure Active Directory Username
 * **Password** -- Password of Active Directory User
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Microsoft Azure` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Microsoft Azure` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description        |
 | ------			 							|----------------- |
@@ -36,13 +35,12 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_PASSWORD			| Password supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/bitbucket.md
+++ b/sources/platform/integration/bitbucket.md
@@ -7,23 +7,23 @@ page_title: Bitbucket integration
 
 Available under the Integration Family: **SCM**
 
-`Bitbucket` Integration is used to connect Shippable DevOps Assembly Lines platform to bitbucket.org. There are 3 ways in which this type of integration can be added
+`Bitbucket` Integration is used to connect Shippable DevOps Assembly Lines platform to bitbucket.org. There are 3 ways in which this type of integration can be added:
 
-* You sign in to Shippable with Bitbucket credentials. In this case, we automatically set up an Account Integration named `Bitbucket` for you. This integration is the default one that we use when you enable CI projects for your repos and sync your permissions with github
-* Second, you can manually add this to your account integrations. This takes in Bitbucket APO `Token` value as input and gives you whatever level of access as the token has
+* You sign in to Shippable with Bitbucket credentials. In this case, we automatically set up an Account Integration named `Bitbucket` for you. This integration is the default one that we use when you enable CI projects for your repos and sync your permissions with Bitbucket.
+* Second, you can manually add this to your account integrations. This takes a Bitbucket APO `Token` value as input and gives you whatever level of access as the token has.
 * Third, if you used another method of signing into Shippable, then from your _Account Profile_ you can connect your Bitbucket account to have multi-provider login to your account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Bitbucket` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Bitbucket` integration.
 
-* [gitRepo](/workflow/platform/resource/gitRepo)
-* [ciRepo](/workflow/platform/resource/ciRepo)
-* [syncRepo](/workflow/platform/resource/syncRepo)
+* [gitRepo](/platform/workflow/resource/gitrepo)
+* [ciRepo](/platform/workflow/resource/cirepo)
+* [syncRepo](/platform/workflow/resource/syncrepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -31,14 +31,12 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to Bitbucket |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-
-

--- a/sources/platform/integration/do.md
+++ b/sources/platform/integration/do.md
@@ -7,22 +7,22 @@ page_title: Amazon ECR integration
 
 Available under the Integration Family: **generic**
 
-`Digital Ocean` Integration is used to connect Shippable DevOps Assembly Lines platform to Digital Ocean cloud to interact with it cloud services to provision machines.
+`Digital Ocean` Integration is used to connect Shippable DevOps Assembly Lines platform to Digital Ocean to interact with its cloud services in order to provision machines.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **API Token** -- Token to connect to Digitial Ocean API
+* **API Token** -- Token to connect to the Digital Ocean API
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Digital Ocean` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Digital Ocean` integration.
 
-* [integration](/workflow/platform/resource/integration)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						         | Description        |
 | ------			 							         |----------------- |
@@ -30,9 +30,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_APITOKEN   | API Token supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/docker-cloud.md
+++ b/sources/platform/integration/docker-cloud.md
@@ -7,25 +7,24 @@ page_title: Docker cloud integration
 
 Available under the Integration Family: **Deploy**
 
-`Docker Cloud` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Cloud so that you can deploy Docker based apps to Docker Cloud
+`Docker Cloud` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Cloud so that you can deploy Docker based apps to Docker Cloud.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Username** -- login to your Docker Cloud Account
-* **Token** -- API Token to deploy of your Docker Cloud Account
+* **Token** -- API Token to deploy to your Docker Cloud Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Docker Cloud` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Docker Cloud` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -33,13 +32,12 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_TOKEN			| Password supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/docker-datacenter.md
+++ b/sources/platform/integration/docker-datacenter.md
@@ -7,9 +7,9 @@ page_title: Docker Datacenter integration
 
 Available under the Integration Family: **Deploy**
 
-`Docker Datacenter` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Datacenter Server so that you cn deploy Docker based applications. 
+`Docker Datacenter` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Datacenter so that you can deploy Docker based applications.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Username** -- login to your Docker Datacenter
@@ -17,16 +17,15 @@ You can create this from the integrations page. This is the information you woul
 * **URL** -- publicly accessible URL of your Docker Datacenter
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Docker Datacenter` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Docker Datacenter` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -35,9 +34,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_URL				| URL supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/docker-hub.md
+++ b/sources/platform/integration/docker-hub.md
@@ -7,9 +7,9 @@ page_title: Docker Hub integration
 
 Available under the Integration Family: **Hub**
 
-`Docker Hub` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Hub so that you can pull and push Docker images. 
+`Docker Hub` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Hub so that you can pull and push Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Username** -- login to your Docker Hub Account
@@ -17,16 +17,15 @@ You can create this from the integrations page. This is the information you woul
 * **Email** -- email of your Docker Hub Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Docker Hub` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Docker Hub` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -35,13 +34,12 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_EMAIL			| Email supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-	

--- a/sources/platform/integration/docker-private-registry.md
+++ b/sources/platform/integration/docker-private-registry.md
@@ -7,9 +7,9 @@ page_title: Docker Private Registry integration
 
 Available under the Integration Family: **Hub**
 
-`Docker Private Registry` Integration is used to connect Shippable DevOps Assembly Lines platform to a privatelty hosted Docker Hub so that you can pull and push Docker images. 
+`Docker Private Registry` Integration is used to connect Shippable DevOps Assembly Lines platform to a privately hosted Docker Hub so that you can pull and push Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **URL** -- location of your private registry. Format `https://foo.com`
@@ -18,16 +18,15 @@ You can create this from the integrations page. This is the information you woul
 * **Email** -- email of your Docker Registry Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Docker Private Registry` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Docker Private Registry` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -37,9 +36,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_EMAIL			| Email supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/docker-trusted-registry.md
+++ b/sources/platform/integration/docker-trusted-registry.md
@@ -7,9 +7,9 @@ page_title: Docker Private/Trusted Registry integration
 
 Available under the Integration Family: **Hub**
 
-`Docker Trusted Registry` Integration is used to connect Shippable DevOps Assembly Lines platform to a privatelty hosted Docker Hub so that you can pull and push Docker images. 
+`Docker Trusted Registry` Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Trusted Registry so that you can pull and push Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **URL** -- location of your private registry. Format `https://foo.com`
@@ -18,16 +18,15 @@ You can create this from the integrations page. This is the information you woul
 * **Email** -- email of your Docker Registry Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Docker Trusted Registry` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Docker Trusted Registry` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -37,9 +36,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_EMAIL			| Email supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/email.md
+++ b/sources/platform/integration/email.md
@@ -6,17 +6,17 @@ page_title: EMail integration
 # EMail Integration
 Available under the Integration Family: **Notifications**
 
-`EMail` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms. 
+`EMail` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to an email address.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **Email Address** -- email address you want to send notifications to. You can add additional addresses when used in a Resource
+* **Email Address** -- email address you want to send notifications to. You can add additional addresses when used in a resource.
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Email` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `Email` integration.
 
-* [ciRepo](/workflow/platform/resource/ciRepo)
+* [ciRepo](/workflow/platform/resource/cirepo)
 * [notification](/workflow/platform/resource/notification)
 
 

--- a/sources/platform/integration/event-trigger.md
+++ b/sources/platform/integration/event-trigger.md
@@ -8,10 +8,10 @@ Available under the Integration Family: **Notifications**
 
 `Event Trigger` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can
 
-* Create daisy chain of projects, so that you can trigger one from another
-* Send a webhook to an external service with custom payloads 
+* Create a daisy chain of projects, so that you can trigger one from another
+* Send a webhook to an external service with custom payloads
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Trigger endpoint** -- Dropdown with following values
@@ -22,26 +22,26 @@ You can create this from the integrations page. This is the information you woul
 		* Authorization -- Token based auth to the external URL
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Event Trigger` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `Event Trigger` integration.
 
-* [notification](/workflow/platform/resource/notification)
-* [ciRepo](/workflow/platform/resource/ciRepo)
+* [notification](/platform/workflow/resource/notification)
+* [ciRepo](/platform/workflow/resource/cirepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
-| `<NAME>`\_INTEGRATION\_PROJECT			| Shippable Project ID  |
+| `<NAME>`\_INTEGRATION\_PROJECT			| Shippable Project ID, for project webhooks  |
 | `<NAME>`\_INTEGRATION\_WEBHOOKURL		| Webhook URL, it is available for Generic Webhooks only |
 | `<NAME>`\_INTEGRATION\_AUTHORIZATION	| Authorization token that was set in the integration  |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/gce.md
+++ b/sources/platform/integration/gce.md
@@ -7,9 +7,9 @@ page_title: GKE integration
 
 Available under the Integration Family: **generic**
 
-`Google Cloud` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Cloud and manage entities and services provided by Google Cloud
+`Google Cloud` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Cloud and manage entities and services provided by Google Cloud.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Project Name** -- Project Name from Google Developers Console
@@ -17,29 +17,27 @@ You can create this from the integrations page. This is the information you woul
 * **Credential File** -- JSON Security Key for Google Cloud
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Google Container Engine` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Google Cloud` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
-* [provision](/workflow/platform/resource/provision)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description      |
 | ------			 							|----------------- |
 | `<NAME>`\_INTEGRATION\_NAME   			      | Name supplied in the integration |
 | `<NAME>`\_INTEGRATION\_PROJECTNAME		      | Project Name supplied in the integration |
-| `<NAME>`\_INTEGRATION\_SERVICEACCOUNTEMAIL  | EMail supplied in the integration |
+| `<NAME>`\_INTEGRATION\_SERVICEACCOUNTEMAIL  | Email address supplied in the integration |
 | `<NAME>`\_INTEGRATION\_CREDENTIALFILE	      | Key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/gcr.md
+++ b/sources/platform/integration/gcr.md
@@ -9,31 +9,30 @@ Available under the Integration Family: **hub**
 
 `GCR` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Container Registry so that you can pull and push Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **JSON Key** -- JSON Security Key for Google Cloud
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `GCR` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `GCR` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description      |
 | ------			 							|----------------- |
 | `<NAME>`\_INTEGRATION\_JSON_KEY			| Access Key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/git-credential.md
+++ b/sources/platform/integration/git-credential.md
@@ -9,7 +9,7 @@ Available under the Integration Family: **generic**
 
 `Git Credential` Integration is used to connect Shippable DevOps Assembly Lines platform to Source Control Systems over HTTP protocol. Typically this happens for public projects by default, but for private projects we always use SSH. In some cases, especially using Git LFS on Bitbucket, it breaks. Hence this is a way you can override the default cloning method
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Host** -- Http/s address to your source control system
@@ -18,14 +18,14 @@ You can create this from the integrations page. This is the information you woul
 * **Password** -- Password to connect to your SCM
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Git Credential` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Git Credential` integration.
 
-* [ciRepo](/workflow/platform/resource/ciRepo)
+* [ciRepo](/platform/workflow/resource/cirepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						         | Description        |
 | ------			 							         |----------------- |
@@ -36,9 +36,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_PASSWORD   	| Password supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/github-enterprise.md
+++ b/sources/platform/integration/github-enterprise.md
@@ -7,35 +7,35 @@ page_title: GitHub Enterprise integration
 
 Available under the Integration Family: **SCM**
 
-`Github Enterprise` Integration is used to connect Shippable DevOps Assembly Lines platform to your instance of Github Enterprise Server. 
+`GitHub Enterprise` Integration is used to connect Shippable DevOps Assembly Lines platform to your instance of GitHub Enterprise Server.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **URL** -- location of your GHE server API. The format is in `https://(Github Enterprise URL)/api/v3`
+* **URL** -- location of your GHE server API. The format is in `https://(GitHub Enterprise URL)/api/v3`
 * **Token** -- personal access token with the right levels of permission
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Github Enterprise` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `GitHub Enterprise` integration.
 
-* [gitRepo](/workflow/platform/resource/gitRepo)
-* [ciRepo](/workflow/platform/resource/ciRepo)
-* [syncRepo](/workflow/platform/resource/syncRepo)
+* [gitRepo](/platform/workflow/resource/gitrepo)
+* [ciRepo](/platform/workflow/resource/cirepo)
+* [syncRepo](/platform/workflow/resource/syncrepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
-| `<NAME>`\_INTEGRATION\_URL    			| Github Enterprise API location |
-| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to Github Enterprise |
+| `<NAME>`\_INTEGRATION\_URL    			| GitHub Enterprise API location |
+| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to GitHub Enterprise |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/github.md
+++ b/sources/platform/integration/github.md
@@ -7,37 +7,36 @@ page_title: GitHub integration
 
 Available under the Integration Family: **SCM**
 
-`Github` Integration is used to connect Shippable DevOps Assembly Lines platform to github.com. There are 3 ways in which this type of integration can be added
+`GitHub` Integration is used to connect Shippable DevOps Assembly Lines platform to github.com. There are 3 ways in which this type of integration can be added:
 
-* You sign in to Shippable with Github credentials. In this case, we automatically set up an Account Integration named `Github` for you. This integration is the default one that we use when you enable CI projects for your repos and sync your permissions with github
-* Second, you can manually add this to your account integrations. This takes in `Token` value as input and gives you whatever level of access as the token has
-* Third, if you used another method of signing into Shippable, then from your _Account Profile_ you can connect your github account to have multi-provider login to your account
+* You sign in to Shippable with GitHub credentials. In this case, we automatically set up an Account Integration named `github` for you. This integration is the default one that we use when you enable CI projects for your repositories and sync your permissions with GitHub.
+* Second, you can manually add this to your account integrations. This takes in `Token` value as input and gives you whatever level of access as the token has.
+* Third, if you used another method of signing into Shippable, then from your _Account Profile_ you can connect your GitHub account to have multi-provider login to your account.
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `github` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `GitHub` integration.
 
-* [gitRepo](/workflow/platform/resource/gitRepo)
-* [ciRepo](/workflow/platform/resource/ciRepo)
-* [syncRepo](/workflow/platform/resource/syncRepo)
+* [gitRepo](/platform/workflow/resource/gitrepo)
+* [ciRepo](/platform/workflow/resource/cirepo)
+* [syncRepo](/platform/workflow/resource/syncrepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
-| `<NAME>`\_INTEGRATION\_URL    			| Github API location |
-| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to correct to Github |
+| `<NAME>`\_INTEGRATION\_URL    			| GitHub API location |
+| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to correct to GitHub |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/gitlab.md
+++ b/sources/platform/integration/gitlab.md
@@ -3,39 +3,39 @@ main_section: Platform
 sub_section: Integrations
 page_title: Gitlab integration
 
-# Gitlab Integration
+# GitLab Integration
 
 Available under the Integration Family: **SCM**
 
-`Gitlab` Integration is used to connect Shippable DevOps Assembly Lines platform to your instance of Gitlab. 
+`GitLab` Integration is used to connect Shippable DevOps Assembly Lines platform to your instance of GitLab.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **URL** -- location of your Gitlab API. The URL should be in the format `https://(GitLab URL)/api/v3`. For example, if you're using gitlab.com, this will `https://gitlab.com/api/v3`
-* **Token** -- Gitlab private token with the right levels of permission
+* **URL** -- location of your GitLab API. The URL should be in the format `https://(GitLab URL)/api/v3`. For example, if you're using gitlab.com, this will `https://gitlab.com/api/v3`
+* **Token** -- GitLab private token with the right levels of permission
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Gitlab` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `GitLab` integration.
 
-* [gitRepo](/workflow/platform/resource/gitRepo)
-* [ciRepo](/workflow/platform/resource/ciRepo)
-* [syncRepo](/workflow/platform/resource/syncRepo)
+* [gitRepo](/platform/workflow/resource/gitrepo)
+* [ciRepo](/platform/workflow/resource/cirepo)
+* [syncRepo](/platform/workflow/resource/syncrepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
-| `<NAME>`\_INTEGRATION\_URL    			| Gitlab API location |
-| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to Gitlab |
+| `<NAME>`\_INTEGRATION\_URL    			| GitLab API location |
+| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to GitLab |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/gke.md
+++ b/sources/platform/integration/gke.md
@@ -7,34 +7,34 @@ page_title: GKE integration
 
 Available under the Integration Family: **deploy**
 
-`Google Container Engine` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Container Engine that runs Kubernetes behind the scenes so that you can deploy Docker based applications
+`Google Container Engine` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Container Engine that runs Kubernetes behind the scenes so that you can deploy Docker based applications.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **JSON Key** -- JSON Security Key for Google Cloud
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Google Container Engine` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Google Container Engine` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
-* [provision](/workflow/platform/resource/provision)
+* [image](/platform/workflow/resource/image)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
+* [loadbalancer](/platform/workflow/resource/loadbalancer)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description      |
 | ------			 							|----------------- |
 | `<NAME>`\_INTEGRATION\_JSON_KEY			| Access Key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/hipchat.md
+++ b/sources/platform/integration/hipchat.md
@@ -7,36 +7,35 @@ page_title: Hipchat integration
 
 Available under the Integration Family: **Notifications**
 
-`Hipchat` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms. 
+`Hipchat` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **Token** -- Hipchat account token
+* **Token** -- HipChat account token
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Hipchat` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `HipChat` integration.
 
-* [notification](/workflow/platform/resource/notification)
-* [ciRepo](/workflow/platform/resource/ciRepo)
+* [notification](/platform/workflow/resource/notification)
+* [ciRepo](/platform/workflow/resource/cirepo)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
-| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to Hipchat |
+| `<NAME>`\_INTEGRATION\_TOKEN			| The Token used to connect to HipChat |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/irc.md
+++ b/sources/platform/integration/irc.md
@@ -6,19 +6,19 @@ page_title: IRC integration
 # IRC Integration
 Available under the Integration Family: **Notifications**
 
-`IRC` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms. 
+`IRC` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 
 We currently support sending notifications to public IRC rooms only.
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `IRC` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `IRC` integration.
 
-* [ciRepo](/workflow/platform/resource/ciRepo)
-* [notification](/workflow/platform/resource/notification)
+* [ciRepo](/platform/workflow/resource/cirepo)
+* [notification](/platform/workflow/resource/notification)
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/jfrog-artifactory.md
+++ b/sources/platform/integration/jfrog-artifactory.md
@@ -7,40 +7,40 @@ page_title: JFrog Artifactory integration
 
 Available under the Integration Family: **hub**
 
-`JFrog Artifactory` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Container Registry so that you can pull and push artifacts including Docker images.
+`JFrog Artifactory` Integration is used to connect Shippable DevOps Assembly Lines platform to JFrog Artifactory so that you can pull and push artifacts including Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **HTTP Endpoint** -- Enter the HTTP Endpoint(url) of your artifact repository
-* **Username** -- Username of your JFrog account 
+* **HTTP Endpoint** -- Enter the HTTP Endpoint (URL) of your artifact repository
+* **Username** -- Username of your JFrog account
 * **Password** -- Password of your JFrog account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `JFrog Artifactory` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `JFrog Artifactory` integration.
 
-* [image](/workflow/platform/resource/image)
-* [integration](/workflow/platform/resource/integration)
+* [file](/platform/workflow/resource/file)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description      |
 | ------			 							|----------------- |
 | `<NAME>`\_INTEGRATION\_URL				| URL supplied in the integration |
-| `<NAME>`\_INTEGRATION\_USERNAME			| USERNAME supplied in the integration |
-| `<NAME>`\_INTEGRATION\_PASSWORD			| PASSWORD supplied in the integration |
+| `<NAME>`\_INTEGRATION\_USERNAME			| Username supplied in the integration |
+| `<NAME>`\_INTEGRATION\_PASSWORD			| Password supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/key-pem.md
+++ b/sources/platform/integration/key-pem.md
@@ -7,32 +7,33 @@ page_title: PEM integration
 
 Available under the Integration Family: **Keys**
 
-`PEM Key` Integration is used to connect Shippable DevOps Assembly Lines platform to VMs that allow PEM based auth. This is typically used to SSH in and then run activities on the machine. Tools like Terraform, Ansible need this to execute scripts on the machine
+`PEM Key` Integration is used to connect Shippable DevOps Assembly Lines platform to VMs that allow PEM based auth. This is typically used to SSH in and then run activities on the machine. Tools like Terraform and Ansible use this to execute scripts on a machine.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Key** -- Encrypted Key in PEM format
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `PEM Key` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `PEM Key` integration.
 
-* [integration](/workflow/platform/resource/integration)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_INTEGRATION\_NAME   			| Name supplied in the integration |
 | `<NAME>`\_INTEGRATION\_KEY				| PEM Key supplied in the integration |
+| `<NAME>`\_INTEGRATION\_KEYPATH				| The path of a file with the PEM Key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/key-ssh.md
+++ b/sources/platform/integration/key-ssh.md
@@ -7,36 +7,38 @@ page_title: SSH keys integration
 
 Available under the Integration Family: **Keys**
 
-`SSH Key` Integration is used to connect Shippable DevOps Assembly Lines platform to VMs that allow PEM based auth. This is typically used to SSH in and then run activities on the machine. Tools like Terraform, Ansible need this to execute scripts on the machine
+`SSH Key` Integration is used to connect Shippable DevOps Assembly Lines platform to VMs that allow SSH based auth. This is typically used to SSH in and then run activities on the machine. Tools like Terraform and Ansible use this to execute scripts on a machine.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **Public Key** -- Public SSH Key 
-* **Private Key** -- Private SSH Key 
+* **Public Key** -- Public SSH Key
+* **Private Key** -- Private SSH Key
 
-You can create your own Keys and store it here or use the Generate Keys button to create a new one
+You can create your own keys and store them here or use the Generate Keys button to create a new one.
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `PEM Key` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with an `SSH Key` integration.
 
-* [integration](/workflow/platform/resource/integration)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_INTEGRATION\_NAME   			| Name supplied in the integration |
 | `<NAME>`\_INTEGRATION\_PUBLICKEY		| Public Key supplied in the integration |
 | `<NAME>`\_INTEGRATION\_PRIVATEKEY		| Private Key supplied in the integration |
+| `<NAME>`\_INTEGRATION\_PUBLIC\_KEY\_PATH		| Path of a file containing the public key supplied in the integration |
+| `<NAME>`\_INTEGRATION\_PRIVATE\_KEY\_PATH		| Path of a file containing the private key supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/key-value.md
+++ b/sources/platform/integration/key-value.md
@@ -9,20 +9,20 @@ Available under the Integration Family: **Generic**
 
 `Key-Value Pair` Integration is used to inject configurations into Shippable DevOps Assembly Lines activities.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Key Values** -- A collection of Key-Values
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Key-Value Pair` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Key-Value Pair` integration.
 
-* [integration](/workflow/platform/resource/integration)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -31,13 +31,12 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | KEY											| Name of the Nth Key defined and will have value set |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)
 * [RunSh Job](/platform/workflow/job/runsh)
 * [Jobs](/platform/workflow/job/overview)
 * [Resources](/platform/workflow/resource/overview)
-

--- a/sources/platform/integration/kubernetes.md
+++ b/sources/platform/integration/kubernetes.md
@@ -6,29 +6,28 @@ page_title: Kubernetes integration
 # Kubernetes Integration
 Available under the Integration Family: **deploy**
 
-`Kubernetes` Integration is used to connect Shippable DevOps Assembly Lines platform to self-hosted Kubernetes so that you can deploy Docker based applications
+`Kubernetes` Integration is used to connect Shippable DevOps Assembly Lines platform to self-hosted Kubernetes so that you can deploy Docker based applications.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **Cluster Access Type** -- dropdown that sets how Shippables accesses your cluster
+* **Cluster Access Type** -- dropdown that sets how Shippable accesses your cluster
 	* Kubernetes Master -- when your master server is publicly accessible
 		* KubeConfig File -- Configuration file to access Kubernetes cluster
-	* Bastion Host -- When you need to access Kube master thats behind a firewall, then you can use a bastion host on the edge publicly accessible to get through the firewall
+	* Bastion Host -- When you need to access Kube master thats behind a firewall, then you can use a publicly accessible bastion host on the edge to get through the firewall
 		* Nodes -- IP address of the Bastion Host
 		* KubeConfig File -- Configuration file to access Kubernetes cluster  
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Kubernetes` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Kubernetes` integration.
 
-* [cluster](/workflow/platform/resource/cluster)
-* [provision](/workflow/platform/resource/provision)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						            | Description      |
 | ------			 							            |----------------- |
@@ -41,9 +40,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_BASTIONPUBLICKEY           | Public Key to access the bastion host |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/node-cluster.md
+++ b/sources/platform/integration/node-cluster.md
@@ -7,24 +7,23 @@ page_title: Node cluster integration
 
 Available under the Integration Family: **deploy**
 
-`Node Clster` Integration is used to connect Shippable DevOps Assembly Lines platform to a cluster of VMs and deploy apps to the entire cluster
+`Node Cluster` Integration is used to connect Shippable DevOps Assembly Lines platform to a cluster of VMs and deploy apps to the entire cluster.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **Username** -- Username to login to Mesos master VM
-* **Validity Period** -- Certificate validity in number of days
+* **Nodes** -- The IP addresses of the nodes in the cluster
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `AWS` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Node Cluster` integration.
 
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description      |
 | ------			 							|----------------- |
@@ -34,9 +33,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_PUBLIKEY			| Public key used to access VMs |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/overview.md
+++ b/sources/platform/integration/overview.md
@@ -4,39 +4,36 @@ sub_section: Integrations
 page_title: Integrations overview
 
 # Integrations Overview
-Integrations are used to connect your Shippable CI or CD workflows to third party platforms or services and also manage secrets that might be needed by your applications. They are owned by users of our platform and the scope feature allows you to decide which organizations/repos have access to use it in their DevOps activities. 
+Integrations are used to connect your Shippable CI or CD workflows to third party platforms or services and manage secrets that might be needed by your applications. They are owned by users of our platform and the scope feature allows you to decide which organizations/repos have access to use it in their DevOps activities.
 
-One the biggest benefits of using Shippable DevOps Assembly Line Integrations as opposed to using encrypted strings that contain the connection information is "Seperation of Concerns". These are the problems of using encrypted strings
+One the biggest benefits of using Shippable DevOps Assembly Line Integrations as opposed to using encrypted strings that contain the connection information is "Separation of Concerns." These are the problems of using encrypted strings:
 
-* The seed key used to encrypt is a single point of failure
-
-* Rotating the see key means you have to change the encrypted strings wherever they are used
-* There is no way to know what was the key that was used to encrypt it, just purely look at the encrypted string. This means aditional DB of what, when, which and how the values were encrypted which is additional work
-* Scripts if they contain the encrypeted values cannot participate in fork based development. The reason for this is that unless every fork has access to the seed key, they will need to use their ecryption and replace these values. This means you will have to add it to `gitignore` so that you dont override the parents encryption values. Changing these scripts through PRs is a pain
-* It is impossible to know which values are present in which enrypted strings, which means I have to decrypt to know what is present in the encrypted values
-* If any one of the values to change, unless you know where its used, there is no way to know which encrypted strings needs to be updated
+* The seed key used to encrypt is a single point of failure.
+* Rotating the seed key means you have to change the encrypted strings wherever they are used.
+* There is no way to know which key that was used to encrypt it purely look at the encrypted string. This means additional DB of what, when, which, and how the values were encrypted which is additional work.
+* Scripts if they contain the encrypted values cannot participate in fork-based development. The reason for this is that unless every fork has access to the seed key, they will need to encrypt and replace these values. This means you will have to add it to `.gitignore` so that you don't override the parent's encrypted values. Changing these scripts through PRs is a pain.
+* It is impossible to know which values are present in which encrypted strings, which means I have to decrypt to know what is present in the encrypted values.
+* If any one of the values to change, unless you know where its used, there is no way to know which encrypted strings need to be updated
 
 In case of Shippable Integrations,
 
-* Internally Shippable is managing encryption at rest and flight which means the users are absolved from worrying about seed keys
+* Internally Shippable is managing encryption at rest and flight which means the users are absolved from worrying about seed keys.
+* Since the integration is used in scripts by reference pointers, changing the integration value in one place automatically propagates across every script that is using it. Maintenance of these integrations becomes trivial.
+* Users of these integrations never need to know what the values are and since the integrations are well documented, they can correctly assume which keys they should use in their scripts.
+* When these integrations are used in certain contexts, the platform automatically logs you in, or configures the CLI, which makes it easy for the script authors to interact with external entities.
+* Removing access is as simple as removing the a repo from the scope and the immediate next run will start to fail.
+* It is a more secure way of maintaining secrets.
 
-* Since the Integration is used in scripts by reference pointers, changing the integration value in 1 place, automatically propogates across every script that is using it. Maintenance of these integrations becomes trivial
-* Users of these integrations never need to know what the values are and since the integrations are well documented, they can assume what keys to use in their scripts
-* When these integrations are using in ceratin contexts, the platform auto-logs your in, or configures the CLI which makes it easy for the script authors to interact with external entities
-* Removing access is as simple as removing the scope to a repo and the immediate next run will start to fail
-* It is a more secure way of maning secrets
-
-We are big believers of the concept where secrets needs to be seperated from scripts for better security and privacy. All integrations are stored in our <a href="https://www.vaultproject.io/">Vault store</a> for maximum security.
+We are big believers in the concept that secrets need to be separated from scripts for better security and privacy. All integrations are stored in our <a href="https://www.vaultproject.io/">Vault store</a> for maximum security.
 
 
-## Supported Integrations 
+## Supported Integrations
 The following are integrations that Shippable currently supports. Detailed information is available on individual integration pages.
 
-- [AWS](/platform/integration/aws)
 - [AWS ECR](/platform/integration/aws-ecr)
 - [AWS IAM](/platform/integration/aws-ecs)
 - [Azure Container Service](/platform/integration/azure-dcos)
-- [Azure DCOS](/platform/integration/azure-dcos)
+- [Azure DC/OS](/platform/integration/azure-dcos)
 - [Azure](/platform/integration/azure)
 - [Bitbucket](/platform/integration/bitbucket)
 - [Digital Ocean](/platform/integration/do)
@@ -45,17 +42,15 @@ The following are integrations that Shippable currently supports. Detailed infor
 - [Docker Hub](/platform/integration/docker-hub)
 - [Docker Trusted Registry](/platform/integration/docker-trusted-registry)
 - [Docker Private Registry](/platform/integration/docker-private-registry)
-- [Email](/platform/integration/email)
 - [Event Trigger](/platform/integration/event-trigger)
 - [Git Credential](/platform/integration/git-credential)
 - [GitHub](/platform/integration/github)
 - [GitHub Enterprise](/platform/integration/github-enterprise)
 - [GitLab](/platform/integration/gitlab)
-- [Google Cloud](/platform/integration/gce) 
+- [Google Cloud](/platform/integration/gce)
 - [Google Container Engine](/platform/integration/gke)
 - [Google Container Registry](/platform/integration/gcr)
 - [HipChat](/platform/integration/hipchat)
-- [IRC](/platform/integration/irc)
 - [JFrog](/platform/integration/jfrog-artifactory)
 - [Joyent Triton](/platform/integration/tripub)
 - [Key-Value Pair](/platform/integration/key-value)

--- a/sources/platform/integration/quay.md
+++ b/sources/platform/integration/quay.md
@@ -7,9 +7,9 @@ page_title: Quay integration
 
 Available under the Integration Family: **Hub**
 
-`Quay` Integration is used to connect Shippable DevOps Assembly Lines platform to Quay Docker Registry so that you can pull and push Docker images. 
+`Quay` Integration is used to connect Shippable DevOps Assembly Lines platform to Quay Docker Registry so that you can pull and push Docker images.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Username** -- login to your Quay Account
@@ -18,15 +18,15 @@ You can create this from the integrations page. This is the information you woul
 * **Access Token** -- access token of your Quay Account
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Docker Hub` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Quay` integration.
 
-* [image](/workflow/platform/resource/image)
-* [cluster](/workflow/platform/resource/cluster)
+* [image](/platform/workflow/resource/image)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
@@ -36,9 +36,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_ACCESSTOKEN		| Access Token supplied in the integration |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/slack.md
+++ b/sources/platform/integration/slack.md
@@ -6,32 +6,33 @@ page_title: Slack integration
 # Slack integration
 Available under the Integration Family: **Notifications**
 
-`Slack` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms. 
+`Slack` Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to channels or rooms.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
-* **WebhookUrl** -- Webhook URL to your slack channel. This can be overriden when creating a Resource. This looks like this `https://hooks.slack.com/services/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`
+* **WebhookUrl** -- Webhook URL to your Slack channel. This can be overridden when creating a resource. This looks like this: `https://hooks.slack.com/services/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`
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `Slack` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Slack` integration.
 
-* [notification](/workflow/platform/resource/notification)
-* [ciRepo](/workflow/platform/resource/ciRepo)
+* [ciRepo](/platform/workflow/resource/cirepo)
+* [integration](/platform/workflow/resource/integration)
+* [notification](/platform/workflow/resource/notification)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description                         |
 | ------------- 								|------------------------------------ |
 | `<NAME>`\_INTEGRATION\_WEBHOOKURL		| Webhook URL of the Integration|
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)

--- a/sources/platform/integration/tripub.md
+++ b/sources/platform/integration/tripub.md
@@ -7,24 +7,24 @@ page_title: Joyent Triton integration
 
 Available under the Integration Family: **deploy**
 
-`Joyent Triton` Integration is used to connect Shippable DevOps Assembly Lines platform to Joyent Triton Container Service to deploy Docker based applications
+`Joyent Triton` Integration is used to connect Shippable DevOps Assembly Lines platform to Joyent Triton Container Service to deploy Docker based applications.
 
-You can create this from the integrations page. This is the information you would require to create this integration
+You can create this from the integrations page. This is the information you would require to create this integration:
 
 * **Name** -- friendly name for the integration
 * **Username** -- Username to login to Mesos master VM
 * **Validity Period** -- Certificate validity in number of days
 
 ## Resources that use this Integration
-Resources are the bulding blocks of assembly lines and some types of resource refer to Integrations by their name. The following Resources Types can created with `AWS` Integration 
+Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Joyent Triton` integration.
 
-* [cluster](/workflow/platform/resource/cluster)
-* [integration](/workflow/platform/resource/integration)
+* [cluster](/platform/workflow/resource/cluster)
+* [integration](/platform/workflow/resource/integration)
 
 ## Default Environment Variables
-When you create a Resource with this integration, and use it as an `IN` or `OUT` into a Job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the Job. These are variables available when this Resource is used
+When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.
 
-`<NAME>` is the the friendly name of the Resource
+`<NAME>` is the the friendly name of the resource.
 
 | Environment variable						| Description      |
 | ------			 							|----------------- |
@@ -35,9 +35,9 @@ When you create a Resource with this integration, and use it as an `IN` or `OUT`
 | `<NAME>`\_INTEGRATION\_PRIVATEKEY		| Private key used to access Triton |
 
 ## Shippable Utility Functions
-To make it easy to GET and SET with these Environment Variables, the platform provides a bunch of utility functions so that you don't need to perform string concatenations etc. to work with this values.
+To make it easy to use these environment variables, the platform provides a command line utility that can be used to work with these values.
 
-How to use these utility functions are [documented here](/platform/tutorial/workflow/howto-use-shipctl)
+How to use these utility functions is [documented here](/platform/tutorial/workflow/howto-use-shipctl).
 
 ## Further Reading
 * [Quick Start to CI](/getting-started/ci-sample)


### PR DESCRIPTION
Fixes broken links, typos, and some grammar.  This also removes some resources listed as using particular integrations that don't and adds some others.  And adds some environment variables to the SSH and PEM key integrations.  I removed a few broken links from the list of integrations in the overview (IRC and email) instead of adding the page to `mkdocs.yml` because it was unclear if these integrations still have any use.