### PR TITLE
fix  broken link to deprecated AMI `Stable`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -376,6 +376,7 @@ pages:
         - AMI v5.5.1: platform/tutorial/runtime/ami-v551.md
         - AMI v5.4.1: platform/tutorial/runtime/ami-v541.md
         - AMI v5.3.2: platform/tutorial/runtime/ami-v532.md
+        - AMI stable: platform/tutorial/runtime/ami-stable.md 
       - API:
         - Overview: platform/tutorial/api/api-overview.md
         - Tokens: platform/tutorial/api/api-tokens.md

--- a/sources/platform/tutorial/runtime/ami-overview.md
+++ b/sources/platform/tutorial/runtime/ami-overview.md
@@ -32,7 +32,7 @@ what is pre-installed on that image:
 | [v5.5.1](ami-v551/)        | Apr 26, 2017    |
 | [v5.4.1](ami-v541/)        | Mar 30, 2017    |
 | [v5.3.2](ami-v532/)        | Mar 11, 2017    |
-| [Stable](machine-image-stable/)      | Feb 19, 2016 (deprecated) |
+| [Stable](ami-stable/)      | Feb 19, 2016 (deprecated) |
 
 **The default Machine Image for your subscription is the latest image available
 when your Subscription was added to Shippable.**


### PR DESCRIPTION
fixes broken link to deprecated AMI named `Stable`

