### PR TITLE
Corrects misinformation in sources/platform/runtime/language.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -272,11 +272,12 @@ pages:
         - Ubuntu 14:04: platform/runtime/os/ubuntu14.md
         - Ubuntu 16:04: platform/runtime/os/ubuntu16.md
       - Languages:
+        - Overview: platform/runtime/language/overview.md
         - Nodejs: platform/runtime/language/nodejs.md
         - Python: platform/runtime/language/python.md
         - Java: platform/runtime/language/java.md
         - Ruby: platform/runtime/language/ruby.md
-        - GO: platform/runtime/language/go.md
+        - Go: platform/runtime/language/go.md
         - PHP: platform/runtime/language/php.md
         - Clojure: platform/runtime/language/clojure.md
         - Scala: platform/runtime/language/scala.md

--- a/sources/platform/runtime/language/clojure.md
+++ b/sources/platform/runtime/language/clojure.md
@@ -5,7 +5,7 @@ sub_sub_section: Languages
 page_title: CI/CD for Clojure Applications
 
 # Clojure
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: clojure` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: clojure` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci)
 
 ```
 language: clojure
@@ -13,24 +13,24 @@ lein:
   - 1.8.0
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `lein` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+The versions of Clojure available vary depending on the tag of the language image; the version specified should be listed in the table for the language image tag used.  The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    | Supported OS
-|----------|---------|-----------
-|1.8.0  |   v5.7.3 and earlier     | All 
-|1.7.0  |   v5.7.3 and earlier     | All 
-|1.6.0  |   v5.7.3 and earlier     | All 
-|1.5.1  |   v5.7.3 and earlier     | All 
-|1.4.0  |   v5.7.3 and earlier     | All 
-|1.3.0  |   v5.7.3 and earlier     | All 
+| Clojure Version  | Language Image Tags | Supported OS
+|------------------|---------------------|-----------
+|1.8.0             |   v5.3.2 and later  | All
+|1.7.0             |   v5.3.2 and later  | All
+|1.6.0             |   v5.3.2 and later  | All
+|1.5.1             |   v5.3.2 and later  | All
+|1.4.0             |   v5.3.2 and later  | All
+|1.3.0             |   v5.3.2 and later  | All
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -48,15 +48,16 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u16cloall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u16cloall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u16cloall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u16cloall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u16cloall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u16cloall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -66,9 +67,10 @@ drydock/u16cloall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u14cloall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u14cloall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u14cloall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u14cloall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u14cloall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u14cloall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -79,4 +81,4 @@ drydock/u14cloall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a Clojure application](/ci/clojure-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/cplusplus.md
+++ b/sources/platform/runtime/language/cplusplus.md
@@ -5,7 +5,7 @@ sub_sub_section: Languages
 page_title: CI/CD for C/C++ Applications
 
 # C/C++
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: c` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: c` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci),
 
 ```
 language: c
@@ -13,23 +13,22 @@ compiler:
   - gcc 6
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `compiler` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+The compiler versions available vary depending on the tag of the language image; the compiler specified should be listed in the table for the language image tag used.  The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    | Supported OS
-|----------|---------|-----------
-|gcc 7.1 |   v5.8.2 and earlier     | All 
-|gcc 6   |  v5.6.1 and earlier | All 
-|clang 4.0.0 |   v5.8.2, v5.7.3     | All 
-|clang 3.9.0 |   v5.6.1 and earlier 
+| Compiler Version | Language Image Tags | Supported OS
+|------------------|---------------------|-----------
+|gcc 7.1           | v5.7.3 and later    | All
+|gcc 6             | v5.6.1 and earlier  | All
+|clang 4.0.0       | v5.7.3 and later    | All
+|clang 3.9.0       | v5.6.1 and earlier  | All
 
-
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -38,7 +37,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -47,13 +46,13 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u16cppall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u16cppall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -66,7 +65,7 @@ drydock/u16cppall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u14cppall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u14cppall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -79,4 +78,4 @@ drydock/u14cppall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a C/C++ application](/ci/cpp-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/go.md
+++ b/sources/platform/runtime/language/go.md
@@ -2,42 +2,41 @@ page_main_title: Go Language Overview
 main_section: Platform
 sub_section: Runtime
 sub_sub_section: Languages
-page_title: CI/CD for GO Applications
+page_title: CI/CD for Go Applications
 
-# GO
-
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: go` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+# Go
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: go` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci)
 
 ```
 language: go
-jdk:
+go:
   - 1.6
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `go` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+Any Go version tag can be used on any image, but using an image that has the required version cached which will improve your build speed. The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    | Supported OS
-|----------|---------|-----------
-|1.8.3   |   v5.7.3     | All 
-|1.7.6   |   v5.7.3    |  All 
-|1.7.5   |  v5.6.1 and earlier |  All 
-|1.7     |  v5.6.1 and earlier |  All 
-|1.6.4   |  v5.6.1 and earlier |  All 
-|1.6     |  v5.6.1 and earlier |  All 
-|1.5.4   |  v5.6.1 and earlier |  All 
-|1.5     |  v5.6.1 and earlier |  All 
-|1.4     |  v5.6.1 and earlier |  All 
-|1.3     |  v5.6.1 and earlier |  All 
-|1.2     |  v5.6.1 and earlier |  All 
-|1.1     |  v5.6.1 and earlier |  All 
+| Go Version | Language Image Tags | Supported OS
+|------------|---------------------|-----------
+|1.8.3       |  v5.7.3 and later   |  All
+|1.7.6       |  v5.7.3 and later   |  All
+|1.7.5       |  v5.6.1 and earlier |  All
+|1.7         |  v5.6.1 and earlier |  All
+|1.6.4       |  v5.6.1 and earlier |  All
+|1.6         |  v5.6.1 and earlier |  All
+|1.5.4       |  v5.6.1 and earlier |  All
+|1.5         |  v5.6.1 and earlier |  All
+|1.4         |  v5.6.1 and earlier |  All
+|1.3         |  v5.6.1 and earlier |  All
+|1.2         |  v5.6.1 and earlier |  All
+|1.1         |  v5.6.1 and earlier |  All
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -46,7 +45,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -56,15 +55,16 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u16golall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u16golall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u16golall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u16golall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u16golall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u16golall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -74,9 +74,10 @@ drydock/u16golall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u14golall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u14golall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u14golall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u14golall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u14golall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u14golall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -86,5 +87,5 @@ drydock/u14golall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
-* [Continuous Integration of a GO application](/ci/go-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [Continuous Integration of a Go application](/ci/go-continuous-integration)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/java.md
+++ b/sources/platform/runtime/language/java.md
@@ -5,7 +5,7 @@ sub_sub_section: Languages
 page_title: CI/CD for Java Applications
 
 # Java
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: java` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: java` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci)
 
 ```
 language: java
@@ -13,24 +13,24 @@ jdk:
   - oraclejdk8
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `jdk` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+The JDKs available vary depending on the tag of the language image; the JDK specified should be listed in the table for the language image tag used. The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    | Supported OS
-|----------|---------|-----------
-|openjdk9  |   v5.7.3    | Ubuntu 16.04 
-|openjdk8  |   v5.7.3 and earlier  |  All 
-|openjdk7  |   v5.7.3 and earlier  |  All 
-|oraclejdk9      |   v5.7.3    | All 
-|oraclejdk8      |   v5.7.3 and earlier  |  All 
-|oraclejdk7      |   v5.5.1 and earlier  |  All 
+| Java JDK  |  Language Image Tags  | Supported OS
+|-----------|-----------------------|-----------
+|openjdk9   |   v5.7.3 and later    |  Ubuntu 16.04
+|openjdk8   |   v5.3.2 and later    |  All
+|openjdk7   |   v5.3.2 and later    |  All
+|oraclejdk9 |   v5.7.3 and later    |  All
+|oraclejdk8 |   v5.3.2 and later    |  All
+|oraclejdk7 |   v5.5.1 and earlier  |  All
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -39,26 +39,27 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
   ci:
-    - gradle assemble    					# if build.gradle is present at root
-    - mvn install -DskipTests=true    	# if pom.xml is present at root
-    - ant test 								# if above 2 cases are false
+    - gradle assemble                 # if build.gradle is present at root
+    - mvn install -DskipTests=true    # if pom.xml is present at root
+    - ant test                        # if above 2 cases are false
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u16javall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u16javall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u16javall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u16javall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u16javall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u16javall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -68,9 +69,10 @@ drydock/u16javall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u14javall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u14javall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u14javall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u14javall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u14javall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u14javall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -80,4 +82,4 @@ drydock/u14javall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a Java application](/ci/java-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/nodejs.md
+++ b/sources/platform/runtime/language/nodejs.md
@@ -5,7 +5,7 @@ sub_sub_section: Languages
 page_title: CI/CD for NodeJS Applications
 
 # Node JS
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: node_js` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: node_js` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci),
 
 ```
 language: node_js
@@ -13,40 +13,40 @@ node_js:
   - 5.12.0
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. If you don't provide `node_js` tag in your YML, the default version is used. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `node_js` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+Any Node JS version tag can be used on any image, but using an image that has the required version cached which will improve your build speed. The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Runtime Image Tags 
-|----------|---------
-|8.2.1  |   v5.8.2    
-|8.1.4  |   v5.7.3    
-|7.10.1 |   v5.7.3, v5.8.2
-|7.4.0  |  v5.6.1 and earlier 
-|7.3.0       |   v5.6.1 and earlier 
-|7.2.1       |  v5.6.1 and earlier 
-|7.0.0         |    v5.6.1 and earlier 
-|6.11.2        |   v5.8.2
-|6.11.1        |   v5.7.3    
-|6.9.4          |  v5.6.1 and earlier 
-|6.8.0          |  v5.6.1 and earlier 
-|6.7.0          |  v5.6.1 and earlier 
-|5.12.0          |  v5.8.2 and earlier
-|4.8.4        |    v5.8.2, v5.7.3   
-|4.6.0          |   v5.6.1 and earlier 
-|4.2.3          |   v5.6.1 and earlier 
-|0.12   **default** |  v5.6.1 and earlier 
-|0.10          |   v5.6.1 and earlier 
-|iojs 1.0  |  v5.6.1 and earlier 
-|iojs 2.0  |  v5.6.1 and earlier 
-|iojs 3.3.1  |  v5.6.1 and earlier 
+| Node JS Version  |  Language Image Tags
+|------------------|---------
+|8.2.1             |  v5.8.2    
+|8.1.4             |  v5.7.3 and later
+|7.10.1            |  v5.7.3 and later
+|7.4.0             |  v5.6.1 and earlier
+|7.3.0             |  v5.6.1 and earlier
+|7.2.1             |  v5.6.1 and earlier
+|7.0.0             |  v5.6.1 and earlier
+|6.11.2            |  v5.8.2
+|6.11.1            |  v5.7.3    
+|6.9.4             |  v5.6.1 and earlier
+|6.8.0             |  v5.6.1 and earlier
+|6.7.0             |  v5.6.1 and earlier
+|5.12.0            |  v5.3.2 and later
+|4.8.4             |  v5.7.3 and later
+|4.6.0             |  v5.6.1 and earlier
+|4.2.3             |  v5.6.1 and earlier
+|0.12  **default** |  v5.6.1 and earlier
+|0.10              |  v5.6.1 and earlier
+|iojs 1.0          |  v5.6.1 and earlier
+|iojs 2.0          |  v5.6.1 and earlier
+|iojs 3.3.1        |  v5.6.1 and earlier
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -55,7 +55,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -65,13 +65,13 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 14.04
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u14nodall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u14nodall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -84,7 +84,7 @@ drydock/u14nodall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u16nodall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u16nodall:v5.7.3  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -97,5 +97,4 @@ drydock/u16nodall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a NodeJS application](/ci/nodejs-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
-
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/overview.md
+++ b/sources/platform/runtime/language/overview.md
@@ -1,0 +1,22 @@
+page_main_title: Overview
+main_section: Platform
+sub_section: Runtime
+sub_sub_section: Languages
+page_title: Language Image Overview
+page_description: List of supported languages
+page_keywords:Continuous Integration, Continuous Deployment, CI/CD, testing, automation, docker, lxc
+
+# Languages
+The Shippable Platform provides images with multiple versions of commonly-used languages pre-installed. A default image will be selected based on the language specified in your [shippable.yml](/platform/tutorial/workflow/shippable-yml/) file when running a CI job, or you can select a different image in the `pre_ci_boot` section of your `shippable.yml`.
+
+Our language specific images that are updated monthly so that the latest and greatest versions are always available for you to test.  See the following pages for more information about which versions are available in each image.
+
+* [C/C++](/platform/runtime/language/cplusplus)
+* [Clojure](/platform/runtime/language/clojure)
+* [Go](/platform/runtime/language/go)
+* [Java](/platform/runtime/language/java)
+* [Node JS](/platform/runtime/language/nodejs)
+* [PHP](/platform/runtime/language/php)
+* [Python](/platform/runtime/language/python)
+* [Ruby](/platform/runtime/language/ruby)
+* [Scala](/platform/runtime/language/scala)

--- a/sources/platform/runtime/language/php.md
+++ b/sources/platform/runtime/language/php.md
@@ -5,7 +5,7 @@ sub_sub_section: Languages
 page_title: CI/CD for PHP Applications
 
 # PHP
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: php` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: php` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci),
 
 ```
 language: php
@@ -13,27 +13,28 @@ php:
   - 7.1
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `php` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+Any PHP version tag can be used on any image, but using an image that has the required version cached which will improve your build speed. The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    | Supported OS
-|----------|---------|-----------
-|7.1.7     |   v5.8.2     | All 
-|7.1.6     |   v5.7.3     | All 
-|7.1       |   v5.6.1 and earlier    |  All 
-|7.0.22  |  v5.8.2      | All 
-|7.0.20  |  v5.7.3      | All 
-|7.0       |   v5.6.1 and earlier    |  All 
-|5.6.31  |  v5.8.2      | All 
-|5.6.30  |  v5.7.3      | All 
-|5.6       |    v5.6.1 and earlier   |  All
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+| PHP Version | Language Image Tags | Supported OS
+|-------------|---------------------|-----------
+|7.1.7        |  v5.8.2             | All
+|7.1.6        |  v5.7.3             | All
+|7.1          |  v5.6.1 and earlier | All
+|7.0.22       |  v5.8.2             | All
+|7.0.20       |  v5.7.3             | All
+|7.0          |  v5.6.1 and earlier | All
+|5.6.31       |  v5.8.2             | All
+|5.6.30       |  v5.7.3             | All
+|5.6          |  v5.6.1 and earlier | All
+
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -42,7 +43,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -51,13 +52,13 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u16phpall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u16phpall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -70,7 +71,7 @@ drydock/u16phpall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u14phpall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u14phpall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -84,4 +85,4 @@ drydock/u14phpall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a PHP application](/ci/php-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/python.md
+++ b/sources/platform/runtime/language/python.md
@@ -6,7 +6,7 @@ page_title: CI/CD for Python Applications
 
 # Python
 
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: python` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: python` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci),
 
 ```
 language: python
@@ -14,35 +14,36 @@ python:
   - 3.4
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `python` tag in your YML, the default version will be used.
 
-| Version     |           Tags         | Supported OS 
-|-------------|------------------------|--------------
-|3.6.2        |   v5.8.2               | All          
-|3.6.1        |   v5.7.3               | All          
-|3.6.0        |   v5.5.1 and earlier   | All          
-|3.5.2        |   v5.8.2 and earlier   | 16.04 only
-|3.5.3        |   v5.8.2 and earlier   | 14.04 only 
-|3.5.2        |   v5.5.1 and earlier   | All
-|3.4.5        |   v5.8.2 and earlier   | 16.04 only 
-|3.4.3        |   v5.8.2 and earlier   | 14.04 only 
-|3.3.6        |   v5.7.3 and earlier   | All        
-|3.2.6        |   v5.6.1 and earlier   | All        
-|2.7.12       |   v5.7.3, v5.8.2       | All        
-|2.7.6        |   v5.6.1 and earlier   | 14.04 only 
-|2.6.9        |   v5.6.1 and earlier   | All        
-|pypy2-v5.8.0 |   v5.7.3               | All        
-|pypy3-v5.8.0 |   v5.7.3               | All        
-|pypy2-v4.0.1 |   v5.6.1 and earlier   | All        
-|pypy3-v2.4.0 |   v5.6.1 and earlier   | All
+The versions of Python available vary depending on the tag of the language image; the Python version specified should be listed in the table for the language image tag used. The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+| Python Version |   Language Image Tags  | Supported OS
+|----------------|------------------------|--------------
+|3.6.2           |   v5.8.2               | All          
+|3.6.1           |   v5.7.3               | All          
+|3.6.0           |   v5.5.1 and earlier   | All          
+|3.5.2           |   v5.8.2 and earlier   | 16.04 only
+|3.5.3           |   v5.8.2 and earlier   | 14.04 only
+|3.5.2           |   v5.5.1 and earlier   | All
+|3.4.5           |   v5.8.2 and earlier   | 16.04 only
+|3.4.3           |   v5.8.2 and earlier   | 14.04 only
+|3.3.6           |   v5.7.3 and earlier   | All        
+|3.2.6           |   v5.6.1 and earlier   | All        
+|2.7.12          |   v5.7.3, v5.8.2       | All        
+|2.7.6           |   v5.6.1 and earlier   | 14.04 only
+|2.6.9           |   v5.6.1 and earlier   | All        
+|pypy2-v5.8.0    |   v5.7.3               | All        
+|pypy3-v5.8.0    |   v5.7.3               | All        
+|pypy2-v4.0.1    |   v5.6.1 and earlier   | All        
+|pypy3-v2.4.0    |   v5.6.1 and earlier   | All
+
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -51,7 +52,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -60,13 +61,13 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u16pytall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u16pytall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -79,7 +80,7 @@ drydock/u16pytall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 drydock/u14pytall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 drydock/u14pytall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -93,4 +94,4 @@ drydock/u14pytall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a Python application](/ci/python-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/ruby.md
+++ b/sources/platform/runtime/language/ruby.md
@@ -5,7 +5,7 @@ sub_sub_section: Languages
 page_title: CI/CD for Ruby Applications
 
 # Ruby
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: ruby` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: ruby` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci),
 
 ```
 language: ruby
@@ -13,38 +13,39 @@ rvm:
   - 2.4.1
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `ruby` tag in your YML, the default version will be used.
 
-| Version  |  Tags    
-|----------|---------
-|2.4.1 |   v5.7.3    
-|2.3.4 |   v5.7.3    
-|2.3.3 |  v5.6.1 and earlier 
-|2.3.2 |  v5.6.1 and earlier 
-|2.3.1 |  v5.6.1 and earlier 
-|2.3.0 |  v5.6.1 and earlier 
-|2.2.7 |   v5.7.3    
-|2.2.5 |  v5.6.1 and earlier 
-|2.2.1 |  v5.6.1 and earlier 
-|2.1.5 |  v5.6.1 and earlier 
-|2.0.0 |  v5.6.1 and earlier 
-|1.9.3 |  v5.6.1 and earlier 
-|1.8.7 |  v5.6.1 and earlier 
-|jruby 9.1.12        |   v5.7.3    
-|jruby 9.1.5         |  v5.6.1 and earlier 
-|jruby 9.1.2         |  v5.6.1 and earlier 
-|jruby 9.0.0         |  v5.7.3 and earlier 
-|jruby 1.7.27        |   v5.7.3    
-|jruby 1.7.19        |  v5.6.1 and earlier 
-|ree 1.8.7           |  v5.6.1 and earlier
+Any Ruby version tag can be used on any image, but using an image that has the required version cached which will improve your build speed. The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+| Ruby Version  |  Language Image Tags    
+|---------------|---------
+|2.4.1          |  v5.7.3 and later
+|2.3.4          |  v5.7.3 and later
+|2.3.3          |  v5.6.1 and earlier
+|2.3.2          |  v5.6.1 and earlier
+|2.3.1          |  v5.6.1 and earlier
+|2.3.0          |  v5.6.1 and earlier
+|2.2.7          |  v5.7.3 and later
+|2.2.5          |  v5.6.1 and earlier
+|2.2.1          |  v5.6.1 and earlier
+|2.1.5          |  v5.6.1 and earlier
+|2.0.0          |  v5.6.1 and earlier
+|1.9.3          |  v5.6.1 and earlier
+|1.8.7          |  v5.6.1 and earlier
+|jruby 9.1.12   |  v5.7.3 and later
+|jruby 9.1.5    |  v5.6.1 and earlier
+|jruby 9.1.2    |  v5.6.1 and earlier
+|jruby 9.0.0    |  v5.3.2 and later
+|jruby 1.7.27   |  v5.7.3 and later
+|jruby 1.7.19   |  v5.6.1 and earlier
+|ree 1.8.7      |  v5.6.1 and earlier
+
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -53,7 +54,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -62,15 +63,16 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16all](/platform/runtime/os/ubuntu16)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u16ruball:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u16ruball:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u16ruball:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u16ruball:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u16ruball:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u16ruball:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -80,9 +82,10 @@ drydock/u16ruball:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14all](/platform/runtime/os/ubuntu14)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u14ruball:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u14ruball:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u14ruball:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u14ruball:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u14ruball:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u14ruball:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -92,4 +95,4 @@ drydock/u14ruball:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a Ruby application](/ci/ruby-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/language/scala.md
+++ b/sources/platform/runtime/language/scala.md
@@ -4,8 +4,8 @@ sub_section: Runtime
 sub_sub_section: Languages
 page_title: CI/CD for Scala Applications
 
-# Scala Job Images
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `language: scala` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci), 
+# Scala
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you set `language: scala` in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci),
 
 ```
 language: scala
@@ -13,25 +13,26 @@ scala:
   - 2.12.2
 ```
 
-We use Ubuntu 14.0 version of the language image by default, the latest that was available when your project was enabled. You can override this by using `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
+The default version of the language image depends on the [machine image](/platform/tutorial/runtime/ami-overview/) selected for the subscription. You can override this by using the `pre_ci_boot` section or even [build your own image](/ci/custom-docker-image) from scratch.
 
 <a name="versions"></a>
 ## Versions
-This table helps you choose the right tag for the language version that your app needs and it is set in the YML. 
+This table helps you choose the right language version tag to set in your `shippable.yml` for your app. If you don't provide a `scala` tag in your YML, the default version will be used.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+The versions of Scala available vary depending on the tag of the language image; the version specified should be listed in the table for the language image tag used.  The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    | Supported OS
-|----------|---------|-----------
-|2.12.2  |   v5.7.3     | All 
-|2.12.1  |   v5.6.1 and earlier    |  All 
-|2.12.0  |   v5.5.1 and earlier    |  All 
-|2.11.11 |   v5.7.3     | All 
-|2.11.8  |   v5.6.1 and earlier    |  All 
-|2.10.6  |   v5.7.3 and earlier    |  All 
-|2.9.3   |   v5.7.3 and earlier    |  All 
+| Scala Version  | Language Image Tags | Supported OS
+|----------------|---------------------|-----------
+|2.12.3          | v5.8.2              | All
+|2.12.2          | v5.7.3              | All
+|2.12.1          | v5.6.1 and earlier  | All
+|2.12.0          | v5.5.1 and earlier  | All
+|2.11.11         | v5.7.3 and later    | All
+|2.11.8          | v5.6.1 and earlier  | All
+|2.10.6          | v5.3.2 and later    | All
+|2.9.3           | v5.3.2 and later    | All
 
-You can use more than 1 of these to test your app against multiple version using [matrix build](/ci/matrix-builds)
+You can use more than one of these to test your app against multiple versions using [matrix builds](/ci/matrix-builds).
 
 ## Default Behavior
 
@@ -40,7 +41,7 @@ build:
   ci: <is not set>
 ```
 
-If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime
+If you do not set the `ci` section of the YML, then we will inject this section to your YML definition at runtime:
 
 ```
 build:
@@ -49,15 +50,16 @@ build:
 ```
 
 ## Shippable provided Runtime images
-Each of the language image is built from the respective base OS version of the image. Since we install all the all the packages, CLIs & services installed on the base image, these language images get this automatically. For more information visit the respective base image page.
+Each of the language images is built from the respective base OS version of the image. Since we install all of the packages, CLIs, and services on the base images, these language images get them automatically. For more information visit the respective base image pages.
 
 ### Ubuntu 16.04
 
 **Built from** [drydock/u16javall](/platform/runtime/language/java)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u16scaall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u16scaall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u16scaall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u16scaall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u16scaall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u16scaall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -67,9 +69,10 @@ drydock/u16scaall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 
 **Built from** [drydock/u14javall](/platform/runtime/language/java)
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
-drydock/u14scaall:v5.7.3  | Jul 2017 - Latest Version | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+drydock/u14scaall:v5.8.2  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
+drydock/u14scaall:v5.7.3  | Jul 2017  | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 drydock/u14scaall:v5.6.1  | Jun 2017  | [v5.6.1](/platform/tutorial/runtime/ami-v561)
 drydock/u14scaall:v5.5.1  | May 2017  | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 drydock/u14scaall:v5.4.1  | Apr 2017  | [v5.4.1](/platform/tutorial/runtime/ami-v541)
@@ -80,6 +83,4 @@ drydock/u14scaall:v5.3.2  | Mar 2017  | [v5.3.2](/platform/tutorial/runtime/ami-
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [Continuous Integration of a Scala application](/ci/scala-continuous-integration)
-* [Checking which AMI is your Project using](/platform/visibility/subscription/nodes)
-
-
+* [How to check which AMI your project is using](/platform/tutorial/runtime/ami-overview/#viewing-subscription-machine-image)

--- a/sources/platform/runtime/overview.md
+++ b/sources/platform/runtime/overview.md
@@ -4,31 +4,31 @@ sub_section: Runtime
 page_title: Job Runtime Overview
 
 # Runtime
-Every activity in your DevOps Assembly Line requires a place to execute that activity. Job Runtime provides that so that the environment is prepped with all the necessary OS, software tools and packages, runtime configurations as well as secrets to authenticate to 3rd party services that the activity might interact with.
+Every activity in your DevOps Assembly Line requires a place to execute that activity. Job Runtime provides that so that the environment is prepped with the necessary OS, software tools and packages, runtime configurations, and secrets to authenticate with 3rd party services that the activity might interact with.
 
-Some of the key benefits of this are
+Some of the key benefits of this are:
 
-* You don't need to constantly change your build environment config as settings, every time a different DevOps activity needs to be performed. For example,
-	* re-configuring your AWS keys depending on whether its a Dev, Test or Prod env;
-	* Constantly having to change environment variables as we work with different tools and software packages;
-	* Having to install multiple different tools/versions like Chef, Puppet and Terraform as different teams use different tools
-* Reduce build time have to constantly prep the environment to run your Job by leveraging caching
-* Having to worry about repeatability in the process as all the config and settings are adhoc, i.e. error prone
-* Reduce the cost of build infrastructure by leveraging Dynamic node creation. Most of the organizations have less than 5% utilization of their build environment
-* Ability to run your build environment behind the firewall and still leverage the SaaS based DevOps Assembly Line platform
+* You don't need to constantly change your build environment configuration every time a different DevOps activity needs to be performed. For example,
+	* Re-configuring your AWS keys depending on whether it's a Dev, Test or Prod environment.
+	* Constantly having to change environment variables as we work with different tools and software packages.
+	* Having to install multiple different tools/versions like Chef, Puppet, and Terraform as different teams use different tools.
+* Reduce build time by leveraging caching instead of constantly prepping the environment to run your job.
+* Not worrying about repeatability in the process as all the config and settings are not ad hoc, i.e. error prone.
+* Reduce the cost of build infrastructure by leveraging dynamic node creation. Most organizations have less than 5% utilization of their build environment.
+* Ability to run your build environment behind a firewall and still leverage the SaaS-based DevOps Assembly Line platform.
 
 ## Components of Job Runtime
-Job Runtime consists of the following components
+Job Runtime consists of the following components.
 
 <a name="os"></a>
 ### Operating System
-Job Runtime is designed to work on any Linux distro. Most of our SaaS customers use Ubuntu and we supply pre-built images for
+Job Runtime is designed to work on any Linux distro. Most of our SaaS customers use Ubuntu and we supply pre-built images for the following.
 
 * [Ubuntu 14.04 LTS](/platform/runtime/os/ubuntu14)
 * [Ubuntu 16.04 LTS](/platform/runtime/os/ubuntu16)
 
 #### Common components installed
-All our images come pre-installed with the following packages....
+All our images come pre-installed with the following packages:
 
 * build-essential
 * curl
@@ -57,12 +57,12 @@ Since we are a Docker based platform, any custom image based on a Linux distro c
 
 <a name="language"></a>
 ### Language
-For both the OS versions, we maintain [language](platform/runtime/language/overview)  specific images that are constantly updated so that the latest and greatest versions are always available for you to test. We update these version on a monthly cadence.
+For both OS versions, we maintain [language](/platform/runtime/language/overview)  specific images that are constantly updated so that the latest and greatest versions are always available for you to test. We update these version on a monthly cadence.
 We support the following languages -
 
 * [C/C++](/platform/runtime/language/cplusplus)
 * [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
+* [Go](/platform/runtime/language/go)
 * [Java](/platform/runtime/language/java)
 * [Node JS](/platform/runtime/language/nodejs)
 * [PHP](/platform/runtime/language/php)
@@ -72,28 +72,28 @@ We support the following languages -
 
 <a name="service"></a>
 ### Services
-To make your builds even faster, we also pre-install a bunch of [Services](platform/runtime/service/overview) that your application may need. These are also updated on a monthly cadence.
+To make your builds even faster, we also pre-install a bunch of [services](/platform/runtime/service/overview) that your application may need. These are also updated on a monthly cadence.
 
-Following are the service that are pre-installed -
+Following are the services that are pre-installed -
 
 * [Cassandra](/platform/runtime/service/cassandra)
 * [CouchDB](/platform/runtime/service/couchdb)
-* [ElasticSearch](/platform/runtime/service/elasticsearch)
+* [Elasticsearch](/platform/runtime/service/elasticsearch)
 * [Memcached](/platform/runtime/service/memcached)
 * [MongoDB](/platform/runtime/service/mongodb)
-* [MySQL](/platform/runtime/service/mongodb)
+* [MySQL](/platform/runtime/service/mysql)
 * [Neo4j](/platform/runtime/service/neo4j)
 * [Postgres](/platform/runtime/service/postgres)
 * [RabbitMQ](/platform/runtime/service/rabbitmq)
 * [Redis](/platform/runtime/service/redis)
-* [RethidDB](/platform/runtime/service/rethinkdb)
+* [RethinkDB](/platform/runtime/service/rethinkdb)
 * [Riak](/platform/runtime/service/riak)
 * [Selenium](/platform/runtime/service/selenium)
-* [SqlLite](/platform/runtime/service/sqllite)
+* [SQLLite](/platform/runtime/service/sqllite)
 
 <a name="cli"></a>
 ### Command Line Interfaces (CLI)
-Majority of the apps today run on cloud. Each cloud provider has a native CLI and we want to avoid you having to install and configure them. In addition we also pre-install some popular DevOps tools also. The goals is to try and prep the build environment as close to your desired state so that you can spend less time prepping and more time developing applications.
+The majority of apps today run in the cloud. Each cloud provider has a native CLI and we want to avoid you having to install and configure them. In addition we also pre-install some popular DevOps tools. The goals is to try and prep the build environment as close to your desired state as possible so that you can spend less time prepping and more time developing applications.
 
 Here is a list of CLIs we have available as part of Job Runtime -
 
@@ -110,36 +110,36 @@ Here is a list of CLIs we have available as part of Job Runtime -
 
 <a name="nodes"></a>
 ### Nodes
-To run you DevOps activities, you need a Node (virtual machine). Shippable support 2 types of Nodes
+To run you DevOps activities, you need a node (virtual machine). Shippable supports 2 types of nodes:
 
-* [Dedicated Dynamic Nodes](/platform/tutorial/runtime/dynamic-nodes) -- these are managed and dynamically provisioned by Shippable Platform. There is no need to worry about managing build infrastructure. There are multiple sizes that you can use depending on your need
-	* 2 core, 3.75GB RAM (default) -- this is equivalent of AWS c4.large instance type
-	* 4 core, 7.5GB RAM -- this is equivalent of AWS c4.xlarge instance type
-	* 8 core, 15GB RAM -- this is equivalent of AWS c4.2xlarge instance type
+* [Dedicated Dynamic Nodes](/platform/tutorial/runtime/dynamic-nodes) -- these are managed and dynamically provisioned by Shippable Platform. There is no need to worry about managing build infrastructure. There are multiple sizes that you can use depending on your need:
+	* 2 core, 3.75GB RAM (default) -- this is equivalent to AWS c4.large instance type
+	* 4 core, 7.5GB RAM -- this is equivalent to AWS c4.xlarge instance type
+	* 8 core, 15GB RAM -- this is equivalent to AWS c4.2xlarge instance type
 
-* [Dedicated Custom Nodes](/platform/tutorial/runtime/custom-nodes) -- these are Nodes that you manage it yourself and hook it to Shippable Assembly Lines to run your DevOps activities. The biggest reason for doing this is that all your code never leaves your infrastructure. Another reason to do this would be that your jobs require access to internal resources that you dont want to be accessible from the internet. You could run these Nodes anywhere you like.
+* [Dedicated Custom Nodes](/platform/tutorial/runtime/custom-nodes) -- these are nodes that you manage yourself and hook to Shippable Assembly Lines to run your DevOps activities. The biggest reason for doing this is that your code never leaves your infrastructure. Another reason to do this would be if your jobs require access to internal resources that you don't want to be accessible from the internet. You can run these nodes anywhere you like.
 
 <a name="env"></a>
 ### Environment variables
-Environment variables are used to control the context of your DevOps activity. Setting this manually everytime you execute a particular activity can be very error prone and missed configurations can cause serious trouble. You might actually be working on a production system when you thought you had your laptop configured to use your test system. To avoid this, Job Runtime provides very many easy ways to inject this into your Job Runtime before you start your activity and also clear the state completely once the activity finishes.
+Environment variables are used to control the context of your DevOps activity. Setting this manually every time you execute a particular activity can be very error prone and missed configurations can cause serious trouble. You might actually be working on a production system when you thought you had your laptop configured to use your test system. To avoid this, Job Runtime provides many very easy ways to inject this into your Job Runtime before you start your activity and clears the state completely once the activity finishes.
 
-Typical use cases for this are
+Typical use cases for this include:
 
 * Configuring your AWS Credentials to connect to a VPC
 * SSH Keys to access your VMs
-* Login to your Docker hub
-* Stage specific application configurations e.g. Dev Settings vs Test Settings
+* Login to your Docker Hub
+* Stage specific application configurations, e.g., Dev Settings vs. Test Settings
 * Logging verbosity for different stages of Software Delivery
-* Docker options for multi stage deployments
+* Docker options for multi-stage deployments
 
-We provide multiple ways to control how environment variables are injected into your Job Runtime. This also varies a bit depending on the [Resource Types](/platform/workflow/resource/overview) you are using. This is applicable to [RunSh](/platform/workflow/job/runsh) and [RunCI](/platform/workflow/job/runci) Job types.
+We provide multiple ways to control how environment variables are injected into your Job Runtime. This also varies a bit depending on the [resource types](/platform/workflow/resource/overview) you are using. Environment variables are most often used with [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) job types.
 
 <a name="cache"></a>
 ### Caching
 
-Caching speeds up your CI builds by automatically setting up your static dependencies. As an example, you can do the following:
+Caching speeds up your CI builds by automatically setting up your static dependencies. As an example, you can cache the following:
 
-- caching node modules
+- node modules
 - ruby gems
 - static binaries from external sources
 


### PR DESCRIPTION
Adds a language overview page (there were links to it and an empty file), corrects some statements on the language pages (14.04 is not always the default), and adds v5.8.2 where it was missing.