### PR TITLE
Corrects platform/runtime/cli.

### DIFF
--- a/sources/platform/runtime/cli/ansible.md
+++ b/sources/platform/runtime/cli/ansible.md
@@ -5,14 +5,14 @@ sub_sub_section: CLIs
 page_title: Ansible CLI Overview
 
 # Ansible CLI
-Ansible is available for all [Jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+Ansible is available for all [jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images with tags since v5.6.1 have this CLI pre-installed.
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -24,7 +24,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -35,14 +35,14 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------
-|2.3.0.0  | v5.8.2 and below
+| 2.3.0.0  | v5.6.1 and above
 
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
-* [CI YML](ci/yml-structure)
+* [CI YML](/ci/yml-structure)
 * [RunSh Job](/platform/workflow/job/runsh)

--- a/sources/platform/runtime/cli/aws.md
+++ b/sources/platform/runtime/cli/aws.md
@@ -5,12 +5,12 @@ sub_sub_section: CLIs
 page_title: AWS CLI Overview
 
 # AWS CLI
-AWS CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The AWS CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) jobs, which you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
-More information is present on [AWS CLI page](https://aws.amazon.com/cli/)
+More information is available on the [AWS CLI page](https://aws.amazon.com/cli/).
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
@@ -37,12 +37,12 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------
-|1.11.91  | v5.8.2
-|1.11.44  | v5.7.3 and below
+|1.11.91   | v5.8.2
+|1.11.44   | v5.7.3 and below
 
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)

--- a/sources/platform/runtime/cli/awseb.md
+++ b/sources/platform/runtime/cli/awseb.md
@@ -6,16 +6,16 @@ page_title: AWS Elastic Beanstalk CLI Overview
 
 # AWS Elastic Beanstalk CLI
 
-AWS Elastic Beanstalk CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The AWS Elastic Beanstalk CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) jobs, which you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
-More information is present on [AWS Elastic Beanstalk page](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html)
+More information is available on the [AWS Elastic Beanstalk page](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html)
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -27,7 +27,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -38,7 +38,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------
@@ -50,4 +50,3 @@ This table helps you choose the right tag based on the version of the CLI you mi
 * [Quick Start to CI](/getting-started/ci-sample)
 * [CI YML](/ci/yml-structure)
 * [RunSh Job](/platform/workflow/job/runsh)
-

--- a/sources/platform/runtime/cli/azure.md
+++ b/sources/platform/runtime/cli/azure.md
@@ -1,19 +1,19 @@
 page_main_title: Azure CLI Overview
 main_section: Platform
-sub_section: Job Runtime
+sub_section: Runtime
 sub_sub_section: CLIs
 page_title: Azure CLI Overview
 
 # Azure CLI
 
-Azure CLI is available for all [Jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The Azure CLI is available for all [jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images with tags since v5.6.1 have this CLI pre-installed.
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -25,7 +25,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -36,12 +36,12 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------
-|2.0.12  | v5.8.2 
-|2.0  | v5.7.3 and below
+|2.0.12    | v5.8.2
+|2.0.6     | v5.6.1 and v5.7.3
 
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)

--- a/sources/platform/runtime/cli/docker.md
+++ b/sources/platform/runtime/cli/docker.md
@@ -6,16 +6,16 @@ page_title: Docker CLI Overview
 
 # Docker CLI
 
-Docker CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The Docker CLI is available in all [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) jobs, which you can execute as part of Shippable DevOps Assembly Lines Platform.
 
-More information is present on [Docker docs page](https://docs.docker.com/engine/platform/commandline/docker)
+More information is available on the [Docker docs page](https://docs.docker.com/engine/reference/commandline/docker).
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -27,7 +27,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -38,7 +38,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------

--- a/sources/platform/runtime/cli/gke.md
+++ b/sources/platform/runtime/cli/gke.md
@@ -4,18 +4,18 @@ sub_section: Runtime
 sub_sub_section: CLIs
 page_title: GKE (GCloud) CLI Overview
 
-# GKE (GCloud) CLI
+# GKE (gcloud) CLI
 
-GCloud CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The Google Cloud (gcloud) CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) jobs, which you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
-More information is present on [Google Cloud docs page](https://cloud.google.com/sdk/gcloud/)
+More information is available on the [Google Cloud docs page](https://cloud.google.com/sdk/gcloud/).
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -27,7 +27,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -38,20 +38,21 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------
-|165.0.0-0  | v5.8.2 (both OS)
-|160.0.0-0  | v5.7.3 and below
+| 165.0.0  | v5.8.2
+| 160.0.0  | v5.7.3
+| 157.0.0  | v5.6.1
+| 151.0.0  | v5.5.1 (Ubuntu 14.04)
+| 148.0.0  | v5.5.1 (Ubuntu 16.04)
+| 148.0.0  | v5.4.1
+| 145.0.0  | v5.3.2 (Ubuntu 16.04)
+| 144.0.0  | v5.3.2 (Ubuntu 14.04)
 
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
 * [CI YML](/ci/yml-structure)
 * [RunSh Job](/platform/workflow/job/runsh)
-
-| Version  |  Tags    | Supported OS|
-|----------|---------|-----------|
-|160.0.0-0  | v5.7.3  | Ubuntu 16.04 |
-|156.0.0-0  | v5.7.3  | Ubuntu 14.04 |

--- a/sources/platform/runtime/cli/jfrog.md
+++ b/sources/platform/runtime/cli/jfrog.md
@@ -6,16 +6,15 @@ page_title: JFrog CLI Overview
 
 # JFrog CLI
 
-JFrog CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The JFrog CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) jobs, which you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
-More information is present on [JFrog CLI page](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory)
+More information is available on the [JFrog CLI page](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory).
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
-
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -27,7 +26,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -38,7 +37,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------

--- a/sources/platform/runtime/cli/kubectl.md
+++ b/sources/platform/runtime/cli/kubectl.md
@@ -6,16 +6,16 @@ page_title: Kubectl CLI Overview
 
 # Kubectl CLI
 
-Kubectl CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+Kubectl CLI is available for [runSh](/platform/workflow/job/runsh) and [runCI](/platform/workflow/job/runci) jobs, which you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
-More information is present on [Kubernetes docs page](https://kubernetes.io/docs/user-guide/kubectl/)
+More information is available on the [Kubernetes docs page](https://kubernetes.io/docs/user-guide/kubectl/).
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -27,7 +27,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -37,7 +37,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 [drydock/u14all:v5.3.2](/platform/runtime/os/ubuntu14#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------

--- a/sources/platform/runtime/cli/packer.md
+++ b/sources/platform/runtime/cli/packer.md
@@ -6,14 +6,14 @@ page_title: Packer CLI Overview
 
 # Packer CLI
 
-Packer CLI is available for all [Jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The Packer CLI is available for all [jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -25,7 +25,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -36,7 +36,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------
@@ -47,4 +47,3 @@ This table helps you choose the right tag based on the version of the CLI you mi
 * [Quick Start to CI](/getting-started/ci-sample)
 * [CI YML](/ci/yml-structure)
 * [RunSh Job](/platform/workflow/job/runsh)
-

--- a/sources/platform/runtime/cli/terraform.md
+++ b/sources/platform/runtime/cli/terraform.md
@@ -6,14 +6,14 @@ page_title: Terraform CLI Overview
 
 # Terraform CLI
 
-Terraform CLI is available for all [Jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images and all Operating Systems support this CLI
+The Terraform CLI is available for all [jobs](/platform/workflow/job/overview) that you can execute as part of Shippable DevOps Assembly Lines Platform. All language images have this CLI pre-installed.
 
 ## Supported OS Versions
-This CLI is installed on to the base OS image along with other CLIs. The following are tags and release dates of the base OS Image
+This CLI is installed in the Shippable base images along with other CLIs. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -25,7 +25,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -36,7 +36,7 @@ This CLI is installed on to the base OS image along with other CLIs. The followi
 
 
 ## Supported Versions
-This table helps you choose the right tag based on the version of the CLI you might want to use
+This table helps you choose the right image tag based on the version of the CLI you want to use.
 
 | Version  |  Tags    
 |----------|---------

--- a/sources/platform/runtime/os/ubuntu14.md
+++ b/sources/platform/runtime/os/ubuntu14.md
@@ -6,37 +6,37 @@ page_title: Ubuntu 14.04 Image for CI
 
 # Ubuntu 14.04
 
-Ubuntu 14.04 based images for Shippable Continuous Integration is available as part of the platform. All our [Language Images](/platform/runtime/languages/overview) are derived from this base image. This image comes pre-installed with latest version of Java, Ruby & Node along with the OS default version of Python. We also install all the [Services](/platform/runtime/service/overview) we support on this image.
+Ubuntu 14.04 based images for Shippable Continuous Integration are available as part of the platform. All our Ubuntu 14.04 [language images](/platform/runtime/language/overview) are derived from this base image. This image comes pre-installed with the latest versions of Java, Ruby, and Node along with the OS default version of Python. We also install all the [services](/platform/runtime/service/overview) we support on this image.
 
-We update this image `drydock/u14all` on a monthly candence and push a unique tag to our [drydock repository](https://hub.docker.com/r/drydock/u14all/) on Docker hub. The tag is of format `<Version>.<Month>.<Release Number>`
+We update this image, `drydock/u14all`, monthly and push a unique tag to our [drydock repository](https://hub.docker.com/r/drydock/u14all/) on Docker Hub. The tag is of the format `<Version>.<Month>.<Release Number>`.
 
 ## Currently Supported Images
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 [drydock/u14all:v5.6.1](/platform/runtime/os/ubuntu14#v561)  | Jun 2017 | [v5.6.1](/platform/tutorial/runtime/ami-v561)
-[drydock/u14all:v5.5.1](/platform/runtime/os/ubuntu14#v551) | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551) 
+[drydock/u14all:v5.5.1](/platform/runtime/os/ubuntu14#v551) | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 [drydock/u14all:v5.4.1](/platform/runtime/os/ubuntu14#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
 [drydock/u14all:v5.3.2](/platform/runtime/os/ubuntu14#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
 
-We support a minimum of 12 tags i.e. 12 months for backward compatability. 
+We support a minimum of 12 tags, i.e. 12 months, for backward compatibility.
 
-These images are pre-packaged into an Amazon Machine Image (AMI) for faster build time. This AMI to boot the VM on which your [runCI](/platform/workflow/job/runci) will execute. You can set which AMI to use for your organization following these [instructions](/ci/build-image).
+These images are pre-packaged into an Amazon Machine Image (AMI) for faster build times. This AMI is used to boot the VM on which your [runCI](/platform/workflow/job/runci) job will execute. You can set which AMI to use for your organization following these [instructions](/ci/build-image).
 
-You can configure different images or even [build](/ci/custom-docker-image) your own from scratch for your [runCI](/platform/workflow/job/runci) Jobs.
+You can configure different images or even [build](/ci/custom-docker-image) your own from scratch for your [runCI](/platform/workflow/job/runci) jobs.
 
 <a name="v582"></a>
 ## Image `drydock/u14all:v5.8.2`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
 * NodeJS - 4.8.4
-* Ruby - 2.3.1
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential - 11.6ubuntu6
 * curl - 7.35.0-1ubuntu2.10
@@ -61,18 +61,19 @@ These are the **Packages** installed
 * dopy - 0.3.7a
 * doctl - jq=1.5+dfsg-1
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
+* ansible - 2.3.0.0
 * awscli - 1.11.91
 * awsebcli - 3.10.3
+* azure - 2.0.12
 * gcloud - 165.0.0
 * jfrog-cli - 1.10.1
 * kubectl - 1.7.2
 * packer - 1.0.3
 * terraform - 0.10.0
-* azure - 2.10.12
 
-These are the **Services** installed
+These are the **Services** installed:
 
 * cassandra - 3.11
 * couchdb - 1.6
@@ -92,302 +93,306 @@ These are the **Services** installed
 <a name="v573"></a>
 ## Image `drydock/u14all:v5.7.3`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.4
-* Ruby - 2.3.1
+* NodeJS - 4.8.3
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential - 11.6ubuntu6
-* curl - 7.35.0-1ubuntu2.10 
-* gcc - 4:4.8.2-1ubuntu6 
-* gettext - 0.18.3.1-1ubuntu3 
-* git - 1:2.13.0-0ppa1~ubuntu14.04.1 
-* htop - 1.0.2-3 
+* curl - 7.35.0-1ubuntu2.10
+* gcc - 4:4.8.2-1ubuntu6
+* gettext - 0.18.3.1-1ubuntu3
+* git - 1:2.13.0-0ppa1~ubuntu14.04.1
+* htop - 1.0.2-3
 * jq - 1.3-1.1ubuntu1
-* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9 
-* libxslt-dev - 1.1.28-2ubuntu0.1 
-* make - 3.81-8.2ubuntu3 
-* nano - 2.2.6-1ubuntu1 
-* openssh-client - 1:6.6p1-2ubuntu2.8 
-* openssl - 1.0.1f-1ubuntu2.22 
+* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9
+* libxslt-dev - 1.1.28-2ubuntu0.1
+* make - 3.81-8.2ubuntu3
+* nano - 2.2.6-1ubuntu1
+* openssh-client - 1:6.6p1-2ubuntu2.8
+* openssl - 1.0.1f-1ubuntu2.22
 * python-dev - 2.7.5-5ubuntu3
 * python-software-properties - 0.92.37.8
-* sudo - 1.8.9p5-1ubuntu1 
-* texinfo - 5.2.0.dfsg.1-2 
-* unzip - 6.0-9ubuntu1.5 
-* virtualenv - 15.1.0 
-* wget - 1.15-1ubuntu1.14.04.2 
+* sudo - 1.8.9p5-1ubuntu1
+* texinfo - 5.2.0.dfsg.1-2
+* unzip - 6.0-9ubuntu1.5
+* virtualenv - 15.1.0
+* wget - 1.15-1ubuntu1.14.04.2
 * dopy - 0.3.7a
 * doctl - jq=1.5+dfsg-1
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
+* ansible - 2.3.0.0
 * awscli - 1.11.44
 * awsebcli - 3.9
+* azure - 2.0.6
 * gcloud - 160.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* cassandra - 3.11 
-* couchdb - 1.6 
-* elasticsearch - 5.5.0 
-* neo4j - 3.2.2 
-* memcached - 1.4.39 
-* mongodb - 3.4.6 
-* mysql - 5.6 
+* cassandra - 3.11
+* couchdb - 1.6
+* elasticsearch - 5.5.0
+* neo4j - 3.2.2
+* memcached - 1.4.39
+* mongodb - 3.4.6
+* mysql - 5.6
 * postgres - 9.6.3  
-* rabbitmq - 3.6.10 
-* redis - 3.2.9 
-* rethinkdb - 2.3.5 
-* riak - 2.2.3 
-* selenium - 3.4.0 
+* rabbitmq - 3.6.10
+* redis - 3.2.9
+* rethinkdb - 2.3.5
+* riak - 2.2.3
+* selenium - 3.4.0
 * sqllite - 3.19.3
 
 <a name="v561"></a>
 ## Image `drydock/u14all:v5.6.1`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
 * NodeJS - 4.8.3
-* Ruby - 2.3.1
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential - 11.6ubuntu6
-* curl - 7.35.0-1ubuntu2.10 
-* gcc - 4:4.8.2-1ubuntu6 
-* gettext - 0.18.3.1-1ubuntu3 
-* git - 1:2.13.0-0ppa1~ubuntu14.04.1 
-* htop - 1.0.2-3 
+* curl - 7.35.0-1ubuntu2.10
+* gcc - 4:4.8.2-1ubuntu6
+* gettext - 0.18.3.1-1ubuntu3
+* git - 1:2.13.0-0ppa1~ubuntu14.04.1
+* htop - 1.0.2-3
 * jq - 1.3-1.1ubuntu1
-* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9 
-* libxslt-dev - 1.1.28-2ubuntu0.1 
-* make - 3.81-8.2ubuntu3 
-* nano - 2.2.6-1ubuntu1 
-* openssh-client - 1:6.6p1-2ubuntu2.8 
-* openssl - 1.0.1f-1ubuntu2.22 
+* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9
+* libxslt-dev - 1.1.28-2ubuntu0.1
+* make - 3.81-8.2ubuntu3
+* nano - 2.2.6-1ubuntu1
+* openssh-client - 1:6.6p1-2ubuntu2.8
+* openssl - 1.0.1f-1ubuntu2.22
 * python-dev - 2.7.5-5ubuntu3
 * python-software-properties - 0.92.37.8
-* sudo - 1.8.9p5-1ubuntu1 
-* texinfo - 5.2.0.dfsg.1-2 
-* unzip - 6.0-9ubuntu1.5 
-* virtualenv - 15.1.0 
-* wget - 1.15-1ubuntu1.14.04.2 
+* sudo - 1.8.9p5-1ubuntu1
+* texinfo - 5.2.0.dfsg.1-2
+* unzip - 6.0-9ubuntu1.5
+* virtualenv - 15.1.0
+* wget - 1.15-1ubuntu1.14.04.2
 * dopy - 0.3.7a
 * doctl - jq=1.5+dfsg-1
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
+* ansible - 2.3.0.0
 * awscli - 1.11.44
 * awsebcli - 3.9
+* azure - 2.0.6
 * gcloud - 157.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.30
-* selenium - 3.4.0 
+* selenium - 3.4.0
 * sqllite - 3.0
 
 
 <a name="v551"></a>
 ## Image `drydock/u14all:v5.5.1`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
 * NodeJS - 4.8.2
-* Ruby - 2.3.1
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential
 * curl
 * gcc
 * gettext
 * git
-* htop 
-* jq 
-* libxml2-dev 
-* libxslt-dev 
-* make 
-* nano 
-* openssh-client 
-* openssl 
-* python-dev 
-* python-software-properties 
-* sudo 
-* texinfo 
-* unzip 
-* virtualenv 
-* wget 
-* dopy 
-* doctl 
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* python-dev
+* python-software-properties
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+* dopy
+* doctl
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
 * awscli - 1.11.44
 * awsebcli - 3.9
-* gcloud - 145.0.0
+* gcloud - 151.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.0
-* selenium - 3.0.1 
+* selenium - 3.0.1
 * sqllite - 3.0
 
 <a name="v541"></a>
 ## Image `drydock/u14all:v5.4.1`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
 * NodeJS - 4.8.1
-* Ruby - 2.3.1
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential
 * curl
 * gcc
 * gettext
 * git
-* htop 
-* jq 
-* libxml2-dev 
-* libxslt-dev 
-* make 
-* nano 
-* openssh-client 
-* openssl 
-* python-dev 
-* python-software-properties 
-* sudo 
-* texinfo 
-* unzip 
-* virtualenv 
-* wget 
-* dopy 
-* doctl 
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* python-dev
+* python-software-properties
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+* dopy
+* doctl
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
 * awscli - 1.11.44
 * awsebcli - 3.9
-* gcloud - 145.0.0
+* gcloud - 148.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.0
-* selenium - 3.0.1 
+* selenium - 3.0.1
 * sqllite - 3.0
 
 
 <a name="v532"></a>
 ## Image `drydock/u14all:v5.3.2`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
 * NodeJS - 4.8.0
 * Ruby - 2.3.1
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential
 * curl
 * gcc
 * gettext
 * git
-* htop 
-* jq 
-* libxml2-dev 
-* libxslt-dev 
-* make 
-* nano 
-* openssh-client 
-* openssl 
-* python-dev 
-* python-software-properties 
-* sudo 
-* texinfo 
-* unzip 
-* virtualenv 
-* wget 
-* dopy 
-* doctl 
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* python-dev
+* python-software-properties
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+* dopy
+* doctl
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
 * awscli - 1.11.44
 * awsebcli - 3.9
-* gcloud - 145.0.0
+* gcloud - 144.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.0
-* selenium - 3.0.1 
+* selenium - 3.0.1
 * sqllite - 3.0

--- a/sources/platform/runtime/os/ubuntu16.md
+++ b/sources/platform/runtime/os/ubuntu16.md
@@ -6,78 +6,78 @@ page_title: Ubuntu 16.04 Image for CI
 
 # Ubuntu 16.04
 
-Ubuntu 16.04 based images for Shippable Continuous Integration is available as part of the platform. All our [Language Images](/platform/runtime/languages/overview) are derived from this base image. This image comes pre-installed with latest version of Java, Ruby & Node along with the OS default version of Python. We also install all the [Services](/platform/runtime/service/overview) we support on this image.
+Ubuntu 16.04 based images for Shippable Continuous Integration are available as part of the platform. All our Ubuntu 16.04 [language images](/platform/runtime/language/overview) are derived from this base image. This image comes pre-installed with the latest versions of Java, Ruby, and Node along with the OS default version of Python. We also install all the [services](/platform/runtime/service/overview) we support on this image.
 
-We update this image `drydock/u16all` on a monthly candence and push a unique tag to our [drydock repository](https://hub.docker.com/r/drydock/u16all/) on Docker hub. The tag is of format `<Version>.<Month>.<Release Number>`
-
+We update this image, `drydock/u16all`, monthly and push a unique tag to our [drydock repository](https://hub.docker.com/r/drydock/u16all/) on Docker Hub. The tag is of the format `<Version>.<Month>.<Release Number>`.
 
 ## Currently Supported Images
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest Version | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
 [drydock/u16all:v5.6.1](/platform/runtime/os/ubuntu16#v561)  | Jun 2017 | [v5.6.1](/platform/tutorial/runtime/ami-v561)
-[drydock/u16all:v5.5.1](/platform/runtime/os/ubuntu16#v551) | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551) 
+[drydock/u16all:v5.5.1](/platform/runtime/os/ubuntu16#v551) | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 [drydock/u16all:v5.4.1](/platform/runtime/os/ubuntu16#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
 [drydock/u16all:v5.3.2](/platform/runtime/os/ubuntu16#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
 
-We support a minimum of 12 tags i.e. 12 months for backward compatability. 
+We support a minimum of 12 tags, i.e. 12 months, for backward compatibility.
 
-These images are pre-packaged into an Amazon Machine Image (AMI) for faster build time. This AMI to boot the VM on which your [runCI](/platform/workflow/job/runci) will execute. You can set which AMI to use for your organization following these [instructions](/ci/build-image).
+These images are pre-packaged into an Amazon Machine Image (AMI) for faster build times. This AMI is used to boot the VM on which your [runCI](/platform/workflow/job/runci) job will execute. You can set which AMI to use for your organization following these [instructions](/ci/build-image).
 
-You can configure different images or even [build](/ci/custom-docker-image) your own from scratch for your [runCI](/platform/workflow/job/runci) Jobs.
+You can configure different images or even [build](/ci/custom-docker-image) your own from scratch for your [runCI](/platform/workflow/job/runci) jobs.
 
 <a name="v582"></a>
 ## Image `drydock/u16all:v5.8.2`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.4
-* Ruby - 2.3.1
+* NodeJS - 7.10.0
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
-*  build-essential - 12.1ubuntu2 
+*  build-essential - 12.1ubuntu2
 *  dopy - 0.3.7a
 *  doctl - jq=1.5+dfsg-1
-*  curl - 7.47.0-1ubuntu2.2 
-*  gcc - 4:5.3.1-1ubuntu1 
-*  gettext - 0.19.7-2ubuntu3 
+*  curl - 7.47.0-1ubuntu2.2
+*  gcc - 4:5.3.1-1ubuntu1
+*  gettext - 0.19.7-2ubuntu3
 *  git - 1:2.13.0-0ppa1~ubuntu16.04.1
-*  htop - 2.0.1-1ubuntu1 
+*  htop - 2.0.1-1ubuntu1
 *  jq - 1.3-1.1ubuntu1
-*  libxml2-dev - 2.9.3+dfsg1-1ubuntu0.2 
-*  libxslt1-dev - 1.1.28-2.1ubuntu0.1 
-*  make - 4.1-6 
-*  nano - 2.5.3-2ubuntu2 
-*  openssh-client - 1:7.2p2-4ubuntu2.1 
-*  openssl - 1.0.2g-1ubuntu4.6 
+*  libxml2-dev - 2.9.3+dfsg1-1ubuntu0.2
+*  libxslt1-dev - 1.1.28-2.1ubuntu0.1
+*  make - 4.1-6
+*  nano - 2.5.3-2ubuntu2
+*  openssh-client - 1:7.2p2-4ubuntu2.1
+*  openssl - 1.0.2g-1ubuntu4.6
 *  python-dev - 2.7.5-5ubuntu3
 *  python-software-properties - 0.92.37.8
-*  software-properties-common - 0.96.20.7 
+*  software-properties-common - 0.96.20.7
 *  sudo - 1.8.16-0ubuntu1.4  
-*  texinfo - 6.1.0.dfsg.1-5 
-*  unzip - 6.0-20ubuntu1 
+*  texinfo - 6.1.0.dfsg.1-5
+*  unzip - 6.0-20ubuntu1
 *  virtualenv - 15.1.0
-*  wget - 1.17.1-1ubuntu1.1 
-*  rsync - 3.1.1-3ubuntu1 
-*  psmisc - 22.21-2.1build1 
+*  wget - 1.17.1-1ubuntu1.1
+*  rsync - 3.1.1-3ubuntu1
+*  psmisc - 22.21-2.1build1
 *  vim - 2:7.4.1689-3ubuntu1.2
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
+* ansible - 2.3.0.0
 * awscli - 1.11.91
 * awsebcli - 3.10.3
+* azure - 2.0.12
 * gcloud - 165.0.0
 * jfrog-cli - 1.10.1
 * kubectl - 1.7.2
 * packer - 1.0.3
 * terraform - 0.10.0
-* azure - 2.0.12
 
-These are the **Services** installed
+These are the **Services** installed:
 
 * cassandra - 3.11
 * couchdb - 1.6
@@ -97,281 +97,285 @@ These are the **Services** installed
 <a name="v573"></a>
 ## Image `drydock/u16all:v5.7.3`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.4
-* Ruby - 2.3.1
+* NodeJS - 7.10.0
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential - 11.6ubuntu6
-* curl - 7.35.0-1ubuntu2.10 
-* gcc - 4:4.8.2-1ubuntu6 
-* gettext - 0.18.3.1-1ubuntu3 
-* git - 1:2.13.0-0ppa1~ubuntu16.04.1 
-* htop - 1.0.2-3 
+* curl - 7.35.0-1ubuntu2.10
+* gcc - 4:4.8.2-1ubuntu6
+* gettext - 0.18.3.1-1ubuntu3
+* git - 1:2.13.0-0ppa1~ubuntu16.04.1
+* htop - 1.0.2-3
 * jq - 1.3-1.1ubuntu1
-* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9 
-* libxslt-dev - 1.1.28-2ubuntu0.1 
-* make - 3.81-8.2ubuntu3 
-* nano - 2.2.6-1ubuntu1 
-* openssh-client - 1:6.6p1-2ubuntu2.8 
-* openssl - 1.0.1f-1ubuntu2.22 
+* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9
+* libxslt-dev - 1.1.28-2ubuntu0.1
+* make - 3.81-8.2ubuntu3
+* nano - 2.2.6-1ubuntu1
+* openssh-client - 1:6.6p1-2ubuntu2.8
+* openssl - 1.0.1f-1ubuntu2.22
 * python-dev - 2.7.5-5ubuntu3
 * python-software-properties - 0.92.37.8
-* sudo - 1.8.9p5-1ubuntu1 
-* texinfo - 5.2.0.dfsg.1-2 
-* unzip - 6.0-9ubuntu1.5 
-* virtualenv - 15.1.0 
-* wget - 1.15-1ubuntu1.14.04.2 
+* sudo - 1.8.9p5-1ubuntu1
+* texinfo - 5.2.0.dfsg.1-2
+* unzip - 6.0-9ubuntu1.5
+* virtualenv - 15.1.0
+* wget - 1.15-1ubuntu1.14.04.2
 * dopy - 0.3.7a
 * doctl - jq=1.5+dfsg-1
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
+* ansible - 2.3.0.0
 * awscli - 1.11.44
 * awsebcli - 3.9
+* azure - 2.0.6
 * gcloud - 160.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* cassandra - 3.11 
-* couchdb - 1.6 
-* elasticsearch - 5.5.0 
-* neo4j - 3.2.2 
-* memcached - 1.4.39 
-* mongodb - 3.4.6 
-* mysql - 5.6 
+* cassandra - 3.11
+* couchdb - 1.6
+* elasticsearch - 5.5.0
+* neo4j - 3.2.2
+* memcached - 1.4.39
+* mongodb - 3.4.6
+* mysql - 5.6
 * postgres - 9.6.3  
-* rabbitmq - 3.6.10 
-* redis - 3.2.9 
-* rethinkdb - 2.3.5 
-* riak - 2.2.3 
-* selenium - 3.4.0 
+* rabbitmq - 3.6.10
+* redis - 3.2.9
+* rethinkdb - 2.3.5
+* riak - 2.2.3
+* selenium - 3.4.0
 * sqllite - 3.19.3
 
 <a name="v561"></a>
 ## Image `drydock/u16all:v5.6.1`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.3
-* Ruby - 2.3.1
+* NodeJS - 7.10.0
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential - 11.6ubuntu6
-* curl - 7.35.0-1ubuntu2.10 
-* gcc - 4:4.8.2-1ubuntu6 
-* gettext - 0.18.3.1-1ubuntu3 
-* git - 1:2.13.0-0ppa1~ubuntu16.04.1 
-* htop - 1.0.2-3 
+* curl - 7.35.0-1ubuntu2.10
+* gcc - 4:4.8.2-1ubuntu6
+* gettext - 0.18.3.1-1ubuntu3
+* git - 1:2.13.0-0ppa1~ubuntu16.04.1
+* htop - 1.0.2-3
 * jq - 1.3-1.1ubuntu1
-* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9 
-* libxslt-dev - 1.1.28-2ubuntu0.1 
-* make - 3.81-8.2ubuntu3 
-* nano - 2.2.6-1ubuntu1 
-* openssh-client - 1:6.6p1-2ubuntu2.8 
-* openssl - 1.0.1f-1ubuntu2.22 
+* libxml2-dev - 2.9.1+dfsg1-3ubuntu4.9
+* libxslt-dev - 1.1.28-2ubuntu0.1
+* make - 3.81-8.2ubuntu3
+* nano - 2.2.6-1ubuntu1
+* openssh-client - 1:6.6p1-2ubuntu2.8
+* openssl - 1.0.1f-1ubuntu2.22
 * python-dev - 2.7.5-5ubuntu3
 * python-software-properties - 0.92.37.8
-* sudo - 1.8.9p5-1ubuntu1 
-* texinfo - 5.2.0.dfsg.1-2 
-* unzip - 6.0-9ubuntu1.5 
-* virtualenv - 15.1.0 
-* wget - 1.15-1ubuntu1.14.04.2 
+* sudo - 1.8.9p5-1ubuntu1
+* texinfo - 5.2.0.dfsg.1-2
+* unzip - 6.0-9ubuntu1.5
+* virtualenv - 15.1.0
+* wget - 1.15-1ubuntu1.14.04.2
 * dopy - 0.3.7a
 * doctl - jq=1.5+dfsg-1
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
+* ansible - 2.3.0.0
 * awscli - 1.11.44
 * awsebcli - 3.9
+* azure - 2.0.6
 * gcloud - 157.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.30
-* selenium - 3.4.0 
+* selenium - 3.4.0
 * sqllite - 3.0
 
 
 <a name="v551"></a>
 ## Image `drydock/u16all:v5.5.1`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.2
-* Ruby - 2.3.1
+* NodeJS - 7.7.4
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential
 * curl
 * gcc
 * gettext
 * git
-* htop 
-* jq 
-* libxml2-dev 
-* libxslt-dev 
-* make 
-* nano 
-* openssh-client 
-* openssl 
-* python-dev 
-* python-software-properties 
-* sudo 
-* texinfo 
-* unzip 
-* virtualenv 
-* wget 
-* dopy 
-* doctl 
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* python-dev
+* python-software-properties
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+* dopy
+* doctl
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
 * awscli - 1.11.44
 * awsebcli - 3.9
-* gcloud - 145.0.0
+* gcloud - 148.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.0
-* selenium - 3.0.1 
+* selenium - 3.0.1
 * sqllite - 3.0
 
 <a name="v541"></a>
 ## Image `drydock/u16all:v5.4.1`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.1
-* Ruby - 2.3.1
+* NodeJS - 7.7.4
+* Ruby - 2.3.3
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential
 * curl
 * gcc
 * gettext
 * git
-* htop 
-* jq 
-* libxml2-dev 
-* libxslt-dev 
-* make 
-* nano 
-* openssh-client 
-* openssl 
-* python-dev 
-* python-software-properties 
-* sudo 
-* texinfo 
-* unzip 
-* virtualenv 
-* wget 
-* dopy 
-* doctl 
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* python-dev
+* python-software-properties
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+* dopy
+* doctl
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
 * awscli - 1.11.44
 * awsebcli - 3.9
-* gcloud - 145.0.0
+* gcloud - 148.0.0
 * jfrog-cli - 1.7.0
 * kubectl - 1.5.1
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.0
-* selenium - 3.0.1 
+* selenium - 3.0.1
 * sqllite - 3.0
 
 
 <a name="v532"></a>
 ## Image `drydock/u16all:v5.3.2`
 
-These are the **Languages** installed
+These are the **Languages** installed:
 
 * Java - 1.8.0
-* NodeJS - 4.8.0
+* NodeJS - 7.6.0
 * Ruby - 2.3.1
 
-These are the **Packages** installed
+These are the **Packages** installed:
 
 * build-essential
 * curl
 * gcc
 * gettext
 * git
-* htop 
-* jq 
-* libxml2-dev 
-* libxslt-dev 
-* make 
-* nano 
-* openssh-client 
-* openssl 
-* python-dev 
-* python-software-properties 
-* sudo 
-* texinfo 
-* unzip 
-* virtualenv 
-* wget 
-* dopy 
-* doctl 
+* htop
+* jq
+* libxml2-dev
+* libxslt-dev
+* make
+* nano
+* openssh-client
+* openssl
+* python-dev
+* python-software-properties
+* sudo
+* texinfo
+* unzip
+* virtualenv
+* wget
+* dopy
+* doctl
 
-These are the **CLIs** installed
+These are the **CLIs** installed:
 
 * awscli - 1.11.44
 * awsebcli - 3.9
@@ -381,18 +385,18 @@ These are the **CLIs** installed
 * packer - 0.12.2
 * terraform - 0.8.7
 
-These are the **Services** installed
+These are the **Services** installed:
 
-* couchdb - 1.6 
-* elasticsearch - 5.1.2 
+* couchdb - 1.6
+* elasticsearch - 5.1.2
 * neo4j - 3.1.1
-* memcached - 1.4.34 
-* mongodb - 3.4 
+* memcached - 1.4.34
+* mongodb - 3.4
 * mysql - 5.6
 * postgres - 9.6  
-* rabbitmq - 3.6 
+* rabbitmq - 3.6
 * redis - 3.2
-* rethinkdb - 2.3 
+* rethinkdb - 2.3
 * riak - 2.2.0
-* selenium - 3.0.1 
+* selenium - 3.0.1
 * sqllite - 3.0


### PR DESCRIPTION
Updates some language and CLI versions to what is in the base images.  And updated the Ansible and Azure CLI pages to reflect that they are not available in versions before v5.6.1.  Most of the line changes in the `os` folder are the editor removing trailing whitespace.