### PR TITLE
Updates versions listed for services.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -294,20 +294,21 @@ pages:
         - Packer: platform/runtime/cli/packer.md
         - Docker: platform/runtime/cli/docker.md
       - Services:
+        - Overview: platform/runtime/service/overview.md
         - Cassandra: platform/runtime/service/cassandra.md
         - Couchdb: platform/runtime/service/couchdb.md
         - Elasticsearch: platform/runtime/service/elasticsearch.md
         - Neo4j: platform/runtime/service/neo4j.md
         - Memcached: platform/runtime/service/memcached.md
-        - Mongodb: platform/runtime/service/mongodb.md
-        - Mysql: platform/runtime/service/mysql.md
+        - MongoDB: platform/runtime/service/mongodb.md
+        - MySQL: platform/runtime/service/mysql.md
         - Postgres: platform/runtime/service/postgres.md
-        - Rabbitmq: platform/runtime/service/rabbitmq.md
+        - RabbitMQ: platform/runtime/service/rabbitmq.md
         - Redis: platform/runtime/service/redis.md
-        - Rethinkdb: platform/runtime/service/rethinkdb.md
+        - RethinkDB: platform/runtime/service/rethinkdb.md
         - Riak: platform/runtime/service/riak.md
         - Selenium: platform/runtime/service/selenium.md
-        - Sqllite: platform/runtime/service/sqllite.md
+        - SQLite: platform/runtime/service/sqllite.md
     - Visibility:
       - Overview: platform/visibility/overview.md
       - Single Pane of Glass: platform/visibility/single-pane-of-glass-spog.md

--- a/sources/ci/rethinkdb.md
+++ b/sources/ci/rethinkdb.md
@@ -6,7 +6,7 @@ sub_section: Working with services
 
 RethinkDB is pre-installed on all Shippable Official images. However, we do not start it by default since not every build needs RethinkDB.
 
-##Starting Riak
+##Starting RethinkDB
 To start RethinkDB, include the following in your `shippable.yml`:
 
 ```

--- a/sources/platform/runtime/os/ubuntu14.md
+++ b/sources/platform/runtime/os/ubuntu14.md
@@ -80,7 +80,7 @@ These are the **Services** installed:
 * elasticsearch - 5.5.1
 * neo4j - 3.2.3
 * memcached - 1.5.0
-* mongodb - 3.4.6
+* mongodb - 3.4.7
 * mysql - 5.6
 * postgres - 9.6.3
 * rabbitmq - 3.6.10
@@ -201,19 +201,20 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.0.15
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.3
+* rabbitmq - 3.6.6
+* redis - 3.2.9
+* rethinkdb - 2.3.5
 * riak - 2.2.30
 * selenium - 3.4.0
-* sqllite - 3.0
+* sqllite - 3.8.2
 
 
 <a name="v551"></a>
@@ -262,19 +263,20 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.0.14
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.2
+* rabbitmq - 3.6.6
+* redis - 3.2.8
+* rethinkdb - 2.3.5
 * riak - 2.2.0
 * selenium - 3.0.1
-* sqllite - 3.0
+* sqllite - 3.8.2
 
 <a name="v541"></a>
 ## Image `drydock/u14all:v5.4.1`
@@ -322,19 +324,20 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.0.14
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.2
+* rabbitmq - 3.6.6
+* redis - 3.2.8
+* rethinkdb - 2.3.5
 * riak - 2.2.0
 * selenium - 3.0.1
-* sqllite - 3.0
+* sqllite - 3.8.2
 
 
 <a name="v532"></a>
@@ -383,16 +386,17 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.0.14
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.2
+* rabbitmq - 3.6.6
+* redis - 3.2.8
+* rethinkdb - 2.3.5
 * riak - 2.2.0
 * selenium - 3.0.1
-* sqllite - 3.0
+* sqllite - 3.8.2

--- a/sources/platform/runtime/os/ubuntu16.md
+++ b/sources/platform/runtime/os/ubuntu16.md
@@ -84,7 +84,7 @@ These are the **Services** installed:
 * elasticsearch - 5.5.1
 * neo4j - 3.2.3
 * memcached - 1.5.0
-* mongodb - 3.4.6
+* mongodb - 3.4.7
 * mysql - 5.7.18
 * postgres - 9.6.3
 * rabbitmq - 3.6.10
@@ -205,19 +205,20 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.4.4
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.3
+* rabbitmq - 3.6.6
+* redis - 3.2.9
+* rethinkdb - 2.3.5
 * riak - 2.2.30
 * selenium - 3.4.0
-* sqllite - 3.0
+* sqllite - 3.11.0
 
 
 <a name="v551"></a>
@@ -266,19 +267,20 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.4.3
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.2
+* rabbitmq - 3.6.6
+* redis - 3.2.8
+* rethinkdb - 2.3.5
 * riak - 2.2.0
 * selenium - 3.0.1
-* sqllite - 3.0
+* sqllite - 3.11.0
 
 <a name="v541"></a>
 ## Image `drydock/u16all:v5.4.1`
@@ -326,19 +328,20 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.4.3
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.2
+* rabbitmq - 3.6.6
+* redis - 3.2.8
+* rethinkdb - 2.3.5
 * riak - 2.2.0
 * selenium - 3.0.1
-* sqllite - 3.0
+* sqllite - 3.11.0
 
 
 <a name="v532"></a>
@@ -387,16 +390,17 @@ These are the **CLIs** installed:
 
 These are the **Services** installed:
 
+* cassandra - 3.9
 * couchdb - 1.6
 * elasticsearch - 5.1.2
 * neo4j - 3.1.1
 * memcached - 1.4.34
-* mongodb - 3.4
+* mongodb - 3.4.2
 * mysql - 5.6
-* postgres - 9.6  
-* rabbitmq - 3.6
-* redis - 3.2
-* rethinkdb - 2.3
+* postgres - 9.6.2
+* rabbitmq - 3.6.6
+* redis - 3.2.8
+* rethinkdb - 2.3.5
 * riak - 2.2.0
 * selenium - 3.0.1
-* sqllite - 3.0
+* sqllite - 3.11.0

--- a/sources/platform/runtime/service/cassandra.md
+++ b/sources/platform/runtime/service/cassandra.md
@@ -1,56 +1,54 @@
 page_main_title: Cassandra Service Overview
 main_section: Platform
-sub_section: Job Runtime
+sub_section: Runtime
 sub_sub_section: Services
 page_title: CI/CD with Cassandra Applications
 
 # Cassandra
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `cassandra` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - cassandra
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags    
 |----------|---------
-|1.6  | v5.7.3, v5.8.2
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 3.11.0   | v5.7.3 and above
+| 3.9      | v5.6.1 and below
 
 ## Supported OS Versions
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+[drydock/u16all:v5.6.1](/platform/runtime/os/ubuntu16#v561)  | Jun 2017 | [v5.6.1](/platform/tutorial/runtime/ami-v561)
+[drydock/u16all:v5.5.1](/platform/runtime/os/ubuntu16#v551)  | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
+[drydock/u16all:v5.4.1](/platform/runtime/os/ubuntu16#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
+[drydock/u16all:v5.3.2](/platform/runtime/os/ubuntu16#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
+
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
+[drydock/u14all:v5.6.1](/platform/runtime/os/ubuntu14#v561)  | Jun 2017 | [v5.6.1](/platform/tutorial/runtime/ami-v561)
+[drydock/u14all:v5.5.1](/platform/runtime/os/ubuntu14#v551)  | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
+[drydock/u14all:v5.4.1](/platform/runtime/os/ubuntu14#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
+[drydock/u14all:v5.3.2](/platform/runtime/os/ubuntu14#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
 
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)

--- a/sources/platform/runtime/service/couchdb.md
+++ b/sources/platform/runtime/service/couchdb.md
@@ -5,42 +5,30 @@ sub_sub_section: Services
 page_title: CI/CD with CouchDB Applications
 
 # CouchDB
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `couchdb` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - couchdb
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags    
 |----------|---------
-|1.6  | v5.8.2 and below
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 1.6.1    | v5.2.3 and above
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -52,7 +40,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/elasticsearch.md
+++ b/sources/platform/runtime/service/elasticsearch.md
@@ -5,19 +5,19 @@ sub_sub_section: Services
 page_title: CI/CD with Elasticsearch Applications
 
 # Elasticsearch
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `elasticsearch` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - elasticsearch
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags    
 |----------|---------
@@ -25,24 +25,12 @@ The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/
 |5.5.0  | v5.7.3  
 |5.1.2  | v5.6.1 and earlier
 
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
-
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -54,7 +42,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/memcached.md
+++ b/sources/platform/runtime/service/memcached.md
@@ -5,44 +5,32 @@ sub_sub_section: Services
 page_title: CI/CD with Memcached Applications
 
 # Memcached
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `memcached` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - memcached
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags    
 |----------|---------
-|1.5.0  | v5.8.2
-|1.4.39  | v5.7.3  
-|1.4.34  | v5.6.1 and earlier
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+|1.5.0     | v5.8.2
+|1.4.39    | v5.7.3  
+|1.4.34    | v5.6.1 and earlier
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -54,7 +42,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/mongodb.md
+++ b/sources/platform/runtime/service/mongodb.md
@@ -5,43 +5,36 @@ sub_sub_section: Services
 page_title: CI/CD with MongoDB Applications
 
 # MongoDB
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `mongo` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
-  - mongodb
+  - mongo
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags    
 |----------|---------
-|3.4.6  | v5.8.2 and earlier  
-|3.4  | v5.6.1 and earlier
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 3.4.7    | v5.8.2
+| 3.4.6    | v5.7.3
+| 3.4.4    | v5.6.1 (Ubuntu 16.04)
+| 3.4.3    | v5.4.1 and v5.5.1 (Ubuntu 16.04)
+| 3.4.2    | v5.2.3 (Ubuntu 16.04)
+| 3.0.15   | v5.6.1 (Ubuntu 14.04)
+| 3.0.14   | v5.5.1 and below (Ubuntu 14.04)
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +46,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/mysql.md
+++ b/sources/platform/runtime/service/mysql.md
@@ -5,44 +5,33 @@ sub_sub_section: Services
 page_title: CI/CD with MySQL Applications
 
 # MySQL
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `mysql` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - mysql
 ```
 
+All language images have this service pre-installed.
+
 ## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+This table helps you choose the right image tag based on the version of the service you want to use.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags   | Supported OS| 
-|----------|---------|-----------|
-|5.7.18  | v5.8.2 and earlier  | Ubuntu 16.04 |
-|5.6  | v5.8.2 and earlier  | Ubuntu 14.04 |
-|5.6  | v5.6.1 and earlier | All |
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| Version |  Tags   | Supported OS|
+|---------|---------|-----------|
+| 5.7.19  | v5.8.2  | Ubuntu 16.04 |
+| 5.7.18  | v5.6.1 and v5.7.3 | Ubuntu 16.04 |
+| 5.7.17  | v5.5.1 and earlier | Ubuntu 16.04 |
+| 5.6.33  | v5.3.2 and later  | Ubuntu 14.04 |
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -54,7 +43,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/neo4j.md
+++ b/sources/platform/runtime/service/neo4j.md
@@ -5,19 +5,19 @@ sub_sub_section: Services
 page_title: CI/CD with Neo4J Applications
 
 # Neo4J
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `neo4j` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - neo4j
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags   
 |----------|---------
@@ -25,24 +25,12 @@ The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/
 |3.2.2  | v5.7.3  
 |3.1.1  | v5.6.1 and earlier  
 
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
-
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -54,7 +42,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/overview.md
+++ b/sources/platform/runtime/service/overview.md
@@ -1,0 +1,27 @@
+page_main_title: Overview
+main_section: Platform
+sub_section: Runtime
+sub_sub_section: Services
+page_title: Services Overview
+page_description: List of supported services
+page_keywords:Continuous Integration, Continuous Deployment, CI/CD, testing, automation, docker, lxc
+
+# Services
+Images provided by the Shippable Platform have services that are often required pre-installed. These services can be started automatically in a [runCI job](/platform/workflow/job/runci).
+
+The following services are available in all of the language specific images.
+
+* [Cassandra](/platform/runtime/service/cassandra)
+* [CouchDB](/platform/runtime/service/couchdb)
+* [Elasticsearch](/platform/runtime/service/elasticsearch)
+* [Memcached](/platform/runtime/service/memcached)
+* [MongoDB](/platform/runtime/service/mongodb)
+* [MySQL](/platform/runtime/service/mysql)
+* [Neo4j](/platform/runtime/service/neo4j)
+* [Postgres](/platform/runtime/service/postgres)
+* [RabbitMQ](/platform/runtime/service/rabbitmq)
+* [Redis](/platform/runtime/service/redis)
+* [RethinkDB](/platform/runtime/service/rethinkdb)
+* [Riak](/platform/runtime/service/riak)
+* [Selenium](/platform/runtime/service/selenium)
+* [SQLLite](/platform/runtime/service/sqllite)

--- a/sources/platform/runtime/service/postgres.md
+++ b/sources/platform/runtime/service/postgres.md
@@ -5,43 +5,31 @@ sub_sub_section: Services
 page_title: CI/CD with Postgres Applications
 
 # Postgres
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `postgres` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - postgres
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags   
 |----------|---------
-|9.6.3 | v5.8.2 and earlier
-|9.6  | v5.6.1 and earlier  
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 9.6.3    | v5.6.1 and later
+| 9.6.2    | v5.5.1 and earlier  
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +41,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -65,4 +53,4 @@ This service is installed on to the base OS image along with other services. The
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
-* [Continuous Integration of a Postgres application](/ci/postgres)
+* [Continuous Integration of a Postgres application](/ci/postgresql)

--- a/sources/platform/runtime/service/rabbitmq.md
+++ b/sources/platform/runtime/service/rabbitmq.md
@@ -5,43 +5,31 @@ sub_sub_section: Services
 page_title: CI/CD with RabbitMQ Applications
 
 # RabbitMQ
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `rabbitmq` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - rabbitmq
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags   
 |----------|---------
-|3.6.10 | v5.8.2 and earlier
-|3.6  | v5.6.1 and earlier  
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 3.6.10   | v5.7.3 and later
+| 3.6.6    | v5.6.1 and earlier  
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +41,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/redis.md
+++ b/sources/platform/runtime/service/redis.md
@@ -5,43 +5,32 @@ sub_sub_section: Services
 page_title: CI/CD with Redis Applications
 
 # Redis
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `redis` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - redis
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags    
 |----------|---------
-|4.0.1  | v5.8.2
-|1.6  | v5.7.3 and below
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 4.0.1  | v5.8.2
+| 3.2.9  | v5.6.1 and v5.7.3
+| 3.2.8  | v5.5.1 and below
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +42,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -61,28 +50,6 @@ This service is installed on to the base OS image along with other services. The
 [drydock/u14all:v5.5.1](/platform/runtime/os/ubuntu14#v551)  | May 2017 | [v5.5.1](/platform/tutorial/runtime/ami-v551)
 [drydock/u14all:v5.4.1](/platform/runtime/os/ubuntu14#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
 [drydock/u14all:v5.3.2](/platform/runtime/os/ubuntu14#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
-
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
-
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
-
-| Version  |  Tags   
-|----------|---------
-|4.0.1  | v5.8.2
-|3.2.9 | v5.7.3  
-|3.2  | v5.6.1 and earlier  
 
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)

--- a/sources/platform/runtime/service/rethinkdb.md
+++ b/sources/platform/runtime/service/rethinkdb.md
@@ -5,42 +5,31 @@ sub_sub_section: Services
 page_title: CI/CD with RethinkDB Applications
 
 # RethinkDB
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `rethinkdb` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - rethinkdb
 ```
 
+All language images have this service pre-installed.
+
 ## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+This table helps you choose the right image tag based on the version of the service you want to use.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
-| Version  |  Tags    
+| Version  |  Tags   
 |----------|---------
-|1.6  | v5.7.3 and below
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+|2.3.6 | v5.8.2  
+|2.3.5 | v5.7.3 and earlier  
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -52,7 +41,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -61,30 +50,7 @@ This service is installed on to the base OS image along with other services. The
 [drydock/u14all:v5.4.1](/platform/runtime/os/ubuntu14#v541)  | Apr 2017 | [v5.4.1](/platform/tutorial/runtime/ami-v541)
 [drydock/u14all:v5.3.2](/platform/runtime/os/ubuntu14#v532)  | Mar 2017 | [v5.3.2](/platform/tutorial/runtime/ami-v532)
 
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
-
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
-
-| Version  |  Tags   
-|----------|---------
-|2.3.6 | v5.8.2  
-|2.3.5 | v5.7.3  
-|2.3  | v5.6.1 and earlier  
-
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
-* [Continuous Integration of a RethinkDB application](/ci/couchdb)
-
+* [Continuous Integration of a RethinkDB application](/ci/rethinkdb)

--- a/sources/platform/runtime/service/riak.md
+++ b/sources/platform/runtime/service/riak.md
@@ -5,43 +5,31 @@ sub_sub_section: Services
 page_title: CI/CD with Riak Applications
 
 # Riak
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `riak` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - riak
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags   
 |----------|---------
-|2.2.3 | v5.7.3  
+|2.2.3 | v5.7.3 and later
 |2.2.0  | v5.6.1 and earlier  
 
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
-
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +41,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/selenium.md
+++ b/sources/platform/runtime/service/selenium.md
@@ -5,43 +5,31 @@ sub_sub_section: Services
 page_title: CI/CD with Selenium Applications
 
 # Selenium
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `selenium` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
   - selenium
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags   
 |----------|---------
-|3.4.0 | v5.8.2 and earlier
-|3.0.1  | v5.5.1 and earlier  
-
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
+| 3.4.0    | v5.6.1 and later
+| 3.0.1    | v5.5.1 and earlier  
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +41,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)

--- a/sources/platform/runtime/service/sqllite.md
+++ b/sources/platform/runtime/service/sqllite.md
@@ -1,47 +1,37 @@
-page_main_title: Sqllite Service Overview
+page_main_title: SQLite Service Overview
 main_section: Platform
 sub_section: Runtime
 sub_sub_section: Services
 page_title: CI/CD with Sqllite Applications
 
-# Sqllite
-This section explain how Shippable DevOps Assembly Lines Platform behaves when you set `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI Job](/platform/workflow/job/runci)
-
-All language images and all Operating Systems support this service
+# SQLite
+This section explains how Shippable DevOps Assembly Lines Platform behaves when you list `sqlite` in the `services:` tag in your [shippable.yml](/platform/tutorial/workflow/shippable-yml) for a [runCI job](/platform/workflow/job/runci).
 
 ```
 services:
-  - sqllite
+  - sqlite
 ```
 
-## Supported Versions
-This table helps you choose the right tag based on the version of the service you might want to use
+All language images have this service pre-installed.
 
-The tags denote which `edition` of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) has that particular version installed. Any tag can be used on any , but each edition of the AMI has that edition cached which will improve your build speed
+## Supported Versions
+This table helps you choose the right image tag based on the version of the service you want to use.
+
+The language image with a particular tag will be available on the edition of the [Runtime AMI](/platform/tutorial/runtime/ami-overview) with the same version number. If you specify an image tag that does not match the Runtime AMI, it will be used but will also increase your build time.
 
 | Version  |  Tags   
 |----------|---------
-|3.19.3 | v5.8.2 and earlier
-|3.0  | v5.6.1 and earlier 
+| 3.19.3   | v5.7.3 and later
+| 3.11.0   | v5.6.1 and earlier (Ubuntu 16.04)
+| 3.8.2    | v5.6.1 and earlier (Ubuntu 14.04)
 
-## Supported Languages
-Since all [Language](/platform/runtime/language/overview) images are built from the the `all` versions of the OS as above, this service is also available if you use language specific images. Shippable platform automatically picks the latest language image based on your [CI YML settings](ci/set-language/), but if you need finer grain control, you can use the image tag sections of the YML.
-
-* [Clojure](/platform/runtime/language/clojure)
-* [GO](/platform/runtime/language/go)
-* [Java](/platform/runtime/language/java)
-* [Node JS](/platform/runtime/language/nodejs)
-* [PHP](/platform/runtime/language/php)
-* [Python](/platform/runtime/language/python)
-* [Ruby](/platform/runtime/language/ruby)
-* [Scala](/platform/runtime/language/scala)
 
 ## Shippable provided Runtime images
-This service is installed on to the base OS image along with other services. The following are tags and release dates of the base OS Image
+This service is installed in the Shippable base images along with other services. The following are tags and release dates of the each base image.
 
 ### Ubuntu 16.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u16all:v5.8.2](/platform/runtime/os/ubuntu16#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u16all:v5.7.3](/platform/runtime/os/ubuntu16#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -53,7 +43,7 @@ This service is installed on to the base OS image along with other services. The
 
 ### Ubuntu 14.04
 
-|Image| Release Date |Available in AMI | 
+|Image| Release Date |Available in AMI |
 |----------|------------|-----|
 [drydock/u14all:v5.8.2](/platform/runtime/os/ubuntu14#v582)  | Aug 2017 - Latest | [v5.8.2](/platform/tutorial/runtime/ami-v582)
 [drydock/u14all:v5.7.3](/platform/runtime/os/ubuntu14#v573)  | Jul 2017 | [v5.7.3](/platform/tutorial/runtime/ami-v573)
@@ -65,4 +55,4 @@ This service is installed on to the base OS image along with other services. The
 ## Further Reading
 * [Everything about Shippable AMIs](/platform/tutorial/runtime/ami-overview)
 * [Quick Start to CI](/getting-started/ci-sample)
-* [Continuous Integration of a Sqllite application](/ci/sqllite)
+* [Continuous Integration of a SQLite application](/ci/sqlite)


### PR DESCRIPTION
* Updates the versions for services to those on the base images with the listed tags.
* Removes the list of languages from each service page; it was more confusing than helpful (all languages support all services).
* Fills in the empty services overview to fix links directing there.