### PR TITLE
#608; updates references to bump and runCLI.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,7 +239,7 @@ pages:
         - provision: platform/workflow/job/provision.md
         - release: platform/workflow/job/release.md
         - runCI: platform/workflow/job/runci.md
-        - runSH: platform/workflow/job/runsh.md
+        - runSh: platform/workflow/job/runsh.md
         - runCLI: platform/workflow/job/runcli.md
         - rSync: platform/workflow/job/rsync.md
       - State:

--- a/sources/ci/env-vars.md
+++ b/sources/ci/env-vars.md
@@ -22,7 +22,7 @@ We support the following kinds of environment variables.
 
 [**User defined environment variables**](#usrEnv) are your custom variables which you can define in the `env` section of your `shippable.yml`. You can define one or multiple variables, as well as encrypt variables to store sensitive information. For example, the snippet below makes the variables $TEST and $FOO available during your build workflow.
 
-[**Unmanaged jobs environment variables**] are environment variables that can be used in [runCI](/platform/workflow/job/runci/) and [runSH](/platform/workflow/job/runsh/) jobs.
+[**Unmanaged jobs environment variables**](/platform/workflow/job/runsh/#default-environment-variables) are environment variables that can be used in [runCI](/platform/workflow/job/runci/) and [runSh](/platform/workflow/job/runsh/) jobs.
 
 ```
 env:

--- a/sources/ci/trigger-pipeline-jobs.md
+++ b/sources/ci/trigger-pipeline-jobs.md
@@ -10,13 +10,13 @@ However, CI is just part of end to end software delivery and most customers also
 
 In this broader end to end workflow, CI is just the first step. This page shows you how you can connect your CI job to the rest of your pipeline.
 
-<img src="../../images/ci/connect-ci-pipelines.png" alt="Add Docker Hub credentials">
+<img src="../../images/ci/connect-ci-pipelines.png" alt="CI to Pipeline">
 
 ##The runCI job
 
-The secret to connecting CI with the rest of your pipeline is the **runCI** job that gets automatically created when you enable a project for CI. You can see this job already in your pipeline by going to the **Pipelines** tab of your Subscription.
+The secret to connecting CI with the rest of your pipeline is the **runCI** job that gets automatically created when you enable a project for CI. You can see this job already in your pipeline by going to your subscription dashboard.
 
-<img src="../../images/ci/runCI-job.png" alt="Add Docker Hub credentials">
+<img src="../../images/ci/runCI-job.png" alt="Subscription Dashboard">
 
 The automatically created job is named with a standard convention of appending **_runCI** to your project name. Follow the steps below to connect it to the next job in your pipeline.
 
@@ -32,7 +32,7 @@ jobs:
       - OUT: my_image
 
   - name: next-job-in-pipeline
-    type: deploy/manifest/runSh/runCLI
+    type: deploy/manifest/runSh
     steps:
       - IN: my_image
 

--- a/sources/deploy/amazon-ecs-naming-conventions.md
+++ b/sources/deploy/amazon-ecs-naming-conventions.md
@@ -32,6 +32,6 @@ Upgrade and replace deployments expect `deployName` to be present during the fir
 
 ## Unmanaged
 
-In an unmanaged scenario, you'll be using a runCLI job with an AWS cliConfig [as described in the unmanaged section of our basic scenario](./amazon-ecs#unmanaged-deployments).
+In an unmanaged scenario, you'll be using a runSh job with an AWS cliConfig [as described in the unmanaged section of our basic scenario](./amazon-ecs#unmanaged-deployments).
 
 Name of the task definition can be given in the taskDefinition.json and service name could be changed via `--service` option in aws command line.

--- a/sources/deploy/amazon-ecs-state-env-vars.md
+++ b/sources/deploy/amazon-ecs-state-env-vars.md
@@ -15,9 +15,9 @@ Managed jobs maintain their own state, and it cannot be customized.  To set envi
 
 ## Unmanaged
 
-In an unmanaged scenario, you'll be using a runCLI job with an AWS cliConfig [as described in the unmanaged section of our basic scenario](./amazon-ecs#unmanaged-deployments).
+In an unmanaged scenario, you'll be using a runSh job with an AWS cliConfig [as described in the unmanaged section of our basic scenario](./amazon-ecs#unmanaged-deployments).
 
-Managing state and utilizing ENVs is a critical part of writing robust runCLI and runSh scripts. This section will give a simple example of using state and ENVs to deploy to two Amazon ECS environments.
+Managing state and utilizing ENVs is a critical part of writing robust runSh scripts. This section will give a simple example of using state and ENVs to deploy to two Amazon ECS environments.
 
 First, we'll need an image to deploy.  This image will be updated automatically via Shippable CI.  You can check the [documentation](../ci/trigger-pipeline-jobs) for instructions on how to set that up.
 
@@ -31,12 +31,12 @@ resources:
       versionName: master.7
 ```
 
-Now we should add this image as an IN to our runCLI job.
+Now we should add this image as an IN to our runSh job.
 
 ```
 jobs:
   - name: myCustomDeployment
-    type: runCLI
+    type: runSh
     steps:
       - IN: MyAwsConfig
       - IN: MyAppImage
@@ -47,7 +47,7 @@ jobs:
 
 ### Environment Variables
 
-By adding resources as `IN` steps, we have automatic access to several environment variables that will be useful for writing generic scripts.  Let's look at an excerpt of a printenv from this runCLI job so that we can see what is available.
+By adding resources as `IN` steps, we have automatic access to several environment variables that will be useful for writing generic scripts.  Let's look at an excerpt of a printenv from this runSh job so that we can see what is available.
 
 Resource-specific ENVs always start with the resource name. Job specific ENVs always start with the word `JOB`.  Shippable-added ENVs are always in all caps.
 
@@ -120,11 +120,11 @@ version:
     desiredCount: 1
 ```
 
-Then add it as an OUT of one runCLI job that determines what the value should be, like this:
+Then add it as an OUT of one runSh job that determines what the value should be, like this:
 
 ```
 name: MyLoadChecker
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
   - IN: MyECSCluster
@@ -141,7 +141,7 @@ Now, you'll want a second job that uses the `params` resource as an IN step.
 
 ```
 name: MyServiceUpdater
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
   - IN: MyECSCluster
@@ -176,15 +176,15 @@ You don't have to rely on other resources to transfer information from one job t
 
 Instead of writing to a `<resourceName>.env` file, just write any file you want to that same state directory, and use the job itself as input to the next job.
 
-Here's an example of a runCLI job that takes another job as IN, and references the previous job's state directory.
+Here's an example of a runSh job that takes another job as IN, and references the previous job's state directory.
 
 ```
 name: MyServiceUpdater
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
   - IN: MyECSCluster
-  - IN: MyLoadChecker  #another runCLI job
+  - IN: MyLoadChecker  #another runSh job
   - TASK:
     - script: ls $MYLOADCHECKER_STATE
     - script: JSON_FILE=$MYLOADCHECKER_STATE/taskdefinitions/sample.json

--- a/sources/deploy/amazon-ecs-unmanaged.md
+++ b/sources/deploy/amazon-ecs-unmanaged.md
@@ -6,9 +6,9 @@ sub_section: Amazon ECS
 
 The managed [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization.
 
-These are called "unmanaged" or "custom" deployments and are implemented with a [runSH job](/platform/workflow/job/runsh/).
+These are called "unmanaged" or "custom" deployments and are implemented with a [runSh job](/platform/workflow/job/runsh/).
 
-This page walks through an example of deploying to Amazon ECS using runCLI.
+This page walks through an example of deploying to Amazon ECS using runSh.
 
 ## Building blocks
 
@@ -22,14 +22,14 @@ You need the following building blocks for this scenario:
 
 **Jobs**
 
-- [runSH](/platform/workflow/job/runsh/)
+- [runSh](/platform/workflow/job/runsh/)
 
 ## Basic deployment
 
 You will need two configuration files:
 
-- `shippable.resources.yml` which contains resource definitions
-- `shippable.jobs.yml` which contains job definitions
+- `shippable.resources.yml`, which contains resource definitions
+- `shippable.jobs.yml`, which contains job definitions
 
 These files should be in your [syncRepo](/platform/workflow/resource/syncrepo/). Please read the [configuration](/deploy/configuration/) to find out how to add a syncRepo to Shippable.
 
@@ -51,7 +51,7 @@ Create an account integration for GitHub by following [instructions here](/platf
 For other source control providers, go to one of these:
 
 - [Bitbucket](/platform/integration/bitbucket/)
-- [Gitlab](/platform/integration/gitlab/)
+- [GitLab](/platform/integration/gitlab/)
 - [GitHub Enterprise](/platform/integration/github-enterprise/)
 
 
@@ -112,13 +112,13 @@ For a complete reference, check out the [gitRepo](/platform/workflow/resource/gi
 
 Jobs are defined in your `shippable.jobs.yml`.
 
-Let's add a basic **runCLI** job which takes in the resources we created above.
+Let's add a basic **runSh** job which takes in the resources we created above.
 
 
 ```
 jobs:
   - name: deploy-ecs-unmanaged-cli
-    type: runCLI
+    type: runSh
     steps:
       - IN: deploy-ecs-unmanaged-config
       - IN: deploy-ecs-unmanaged-image
@@ -181,7 +181,7 @@ Your pipeline should look like this:
 
 ###5: Trigger your pipeline
 
-Right click on the **runCLI** job, select "run job", and you should get some output from AWS like this:
+Right click on the **runSh** job, select "run job", and you should get some output from AWS like this:
 <img src="../../images/deploy/amazon-ecs/basic-deployment-runcli-output.png" alt="runCLI Output">
 
 And if you check ECS, you should see your service running your task definition!
@@ -190,7 +190,7 @@ And if you check ECS, you should see your service running your task definition!
 ## Sample project
 
 Here are some links to a working sample of this scenario. This is a simple Node.js application that runs some tests and then pushes
-the image to Amazon ECR. It also contains all of the pipelines configuration files for deploying to Amazon ECS via runCLI job.
+the image to Amazon ECR. It also contains all of the pipelines configuration files for deploying to Amazon ECS via runSh job.
 
 **Source code:**  [devops-recipes/deploy-ecs-unmanaged](https://github.com/devops-recipes/deploy-ecs-unmanaged)
 
@@ -204,7 +204,7 @@ You can run your awscli commands against any cluster and region that you want. D
 
 ##Attaching a load balancer
 
-If your load balancer is already created on AWS, deploying with it in a **runCLI** job should be as simple as just adding the `LoadBalancers` array to your service template as described [here](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-service.html).
+If your load balancer is already created on AWS, deploying with it in a **runSh** job should be as simple as just adding the `LoadBalancers` array to your service template as described [here](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-service.html).
 
 Note that a service that's already running cannot be updated with a load balancer.  You'll have to destroy/create the service from scratch with the load balancer for it to take effect.  Shippable's [managed deploy jobs](../platform/workflow/job/deploy) handle scenarios like this automatically for you.
 
@@ -218,14 +218,14 @@ Update your **sampleTaskDef.json** to include any additional settings you'd like
 
 ## Using State and Environment Variables
 
-Managing state and utilizing ENVs is a critical part of writing robust runCLI and runSh scripts. This section will give a simple example of using state and ENVs to deploy to two Amazon ECS environments.
+Managing state and utilizing ENVs is a critical part of writing robust runSh scripts. This section will give a simple example of using state and ENVs to deploy to two Amazon ECS environments.
 
 In the above sample project, we used an image IN along with `shippable_replace` to fill in our task definition on the fly.  This is utilizing Shippable's built-in resource ENVs.
 
 
 ### Environment Variables
 
-By adding resources as `IN` steps, we have automatic access to several environment variables that will be useful for writing generic scripts.  Let's look at an excerpt of a printenv from this runCLI job so that we can see what is available.
+By adding resources as `IN` steps, we have automatic access to several environment variables that will be useful for writing generic scripts.  Let's look at an excerpt of a printenv from this runSh job so that we can see what is available.
 
 Resource-specific ENVs always start with the resource name. Job specific ENVs always start with the word `JOB`.  Shippable-added ENVs are always in all caps.
 
@@ -273,11 +273,11 @@ version:
     desiredCount: 1
 ```
 
-Then add it as an OUT of one runCLI job that determines what the value should be, like this:
+Then add it as an OUT of one runSh job that determines what the value should be, like this:
 
 ```
 name: MyLoadChecker
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
   - IN: MyECSCluster
@@ -294,7 +294,7 @@ Now, you'll want a second job that uses the `params` resource as an IN step.
 
 ```
 name: MyServiceUpdater
-type: runCLI
+type: runSh
 steps:
   - IN: deploy-ecs-unmanaged-config
   - IN: deploy-ecs-unmanaged-image
@@ -330,14 +330,14 @@ You don't have to rely on other resources to transfer information from one job t
 
 Instead of writing to a `<resourceName>.env` file, just write any file you want to that same state directory, and use the job itself as input to the next job.
 
-Here's an example of a runCLI job that takes another job as IN, and references the previous job's state directory.
+Here's an example of a runSh job that takes another job as IN, and references the previous job's state directory.
 
 ```
 name: MyServiceUpdater
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
-  - IN: MyLoadChecker  #another runCLI job
+  - IN: MyLoadChecker  #another runSh job
   - TASK:
     - script: ls $MYLOADCHECKER_STATE
     - script: JSON_FILE=$MYLOADCHECKER_STATE/myService.json

--- a/sources/deploy/aws-elastic-beanstalk-multiple-containers.md
+++ b/sources/deploy/aws-elastic-beanstalk-multiple-containers.md
@@ -5,7 +5,7 @@ sub_sub_section: AWS Elastic Beanstalk
 
 # Deploy multiple containers to a single EB environment.
 
-The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring over your existing proven CLI based deployment scripts over to Shippable.  This page walks through an example of using the Elastic Beanstalk (EB) CLI to  deploy a multiple container application to your EB environment.
+The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring your existing proven CLI based deployment scripts over to Shippable.  This page walks through an example of using the Elastic Beanstalk (EB) CLI to  deploy a multiple container application to your EB environment.
 
 ## Topics Covered
 
@@ -23,11 +23,11 @@ We will be defining the jobs and resources in a step by step manner below.
 
 They are four configuration files that are needed to achieve this usecase -
 
-* **[shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/):** Resources are defined in this file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* **[shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/):** Resources are defined in this file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* **[shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/):** Jobs are defined in this file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* **[shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/):** Jobs are defined in this file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
-* **`Dockerrun.aws.json`**: This file specifies the image and environment configuration. Placeholders are defined in this file for the image and environment configuration. These Placeholders give us flexibility to use the image and environment configuration that you will define in Shippable configuration files.
+* **`Dockerrun.aws.json`**: This file specifies the image and environment configuration. Placeholders are defined in this file for the image and environment configuration. These placeholders give us flexibility to use the image and environment configuration that you will define in Shippable configuration files.
 
 Content of [`Dockerrun.aws.json`](https://raw.githubusercontent.com/devops-recipes/deploy-beanstalk-basic/master/multi_container/Dockerrun.aws.json)
 ```
@@ -67,7 +67,7 @@ Content of [`Dockerrun.aws.json`](https://raw.githubusercontent.com/devops-recip
 
 * **`config.yml`**:
 
-In your source code, along side the `Dockerrun.aws.json` file, create a `.elasticbeanstalk` directory and create a `config.yml` file inside it. In our sample, we have a `multi_container` folder that contains our `Dockerrun.aws.json` for this example. The file tree looks like this:
+In your source code, alongside the `Dockerrun.aws.json` file, create a `.elasticbeanstalk` directory and create a `config.yml` file inside it. In our sample, we have a `multi_container` folder that contains our `Dockerrun.aws.json` for this example. The file tree looks like this:
 ```
 multi_container/
 ├── Dockerrun.aws.json
@@ -99,9 +99,9 @@ global:
   workspace_type: Application
 ```
 
-Inside `config.yml`, you will see placeholders defined for application, environment and region. These placeholders will be replaced dynamically with your Shippable configuration giving you tremendous flexibility and reuse.
+Inside `config.yml`, you will see placeholders defined for application, environment, and region. These placeholders will be replaced dynamically with your Shippable configuration giving you tremendous flexibility and reuse.
 
-## Prequisites
+## Prerequisites
 
 ### Create a Beanstalk application and environment
 
@@ -117,7 +117,7 @@ Once the creation is done, you should see this:
 
 ###1. Define `deploy-eb-basic-image` and `deploy-eb-nginx-image`.
 
-* **Description:** `deploy-eb-basic-image` and `deploy-eb-nginx-image` represent the docker images of our sample application. In our example, these images hosted on Amazon ECR.
+* **Description:** `deploy-eb-basic-image` and `deploy-eb-nginx-image` represent the Docker images of our sample application. In our example, these images hosted on Amazon ECR.
 * **Required:** Yes.
 
 2. Add the following yml block to your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file.
@@ -144,7 +144,7 @@ resources:
 
 ###2. Define `deploy-eb-basic-config`.
 
-* **Description:** `deploy-eb-basic-config` is a [cliConfig](/platform/workflow/resource/cliconfig/#cliconfig) resource that references credentials needed to setup a CLI for EB.
+* **Description:** `deploy-eb-basic-config` is a [cliConfig](/platform/workflow/resource/cliconfig/) resource that references credentials needed to setup a CLI for EB.
 
 * **Required:** Yes.
 
@@ -170,7 +170,7 @@ resources:
 
 ###3. Define `deploy-eb-basic-params`
 
-* **Description:** `deploy-eb-basic-params` is a [params](/platform/workflow/resource/params/#params) resource that defines variables we want to make easily configurable. These variables definitions replace the placeholders in the `Docker.aws.json` and `config.yml` files.
+* **Description:** `deploy-eb-basic-params` is a [params](/platform/workflow/resource/params/) resource that defines variables we want to make easily configurable. These variables are used to replace the placeholders in the `Dockerrun.aws.json` and `config.yml` files.
 
 * **Required:** Yes.
 
@@ -192,7 +192,7 @@ resources:
 
 ###4. Define `deploy-eb-basic-repo`
 
-* **Description:** `deploy-eb-basic-repo` is a [gitRepo](/platform/workflow/resource/gitrepo/#gitrepo) resource which represents the repository of our application that has all the source and the configuration files we created earlier. We need this resource to access and replace content dynamically in the `Docker.aws.json` and `config.yml` files.  
+* **Description:** `deploy-eb-basic-repo` is a [gitRepo](/platform/workflow/resource/gitrepo/) resource which represents our application repository that has all the source and the configuration files we created earlier. We need this resource to access and replace content dynamically in the `Dockerrun.aws.json` and `config.yml` files.  
 
 * **Required:** Yes.
 
@@ -212,14 +212,14 @@ resources:
 
 ###5. Define `deploy-eb-basic-deploy`
 
-* **Description:** `deploy-eb-basic-deploy` is a [runSH](/platform/workflow/job/runsh/) job that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted.
+* **Description:** `deploy-eb-basic-deploy` is a [runSh](/platform/workflow/job/runsh/) job that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted.
 
-    We're going to use the ebcli to perform the deployment, since it comes pre-installed on the build image, and it takes care of a lot of the work for us.  Since we've manually added the config.yml, and our aws cli is already configured with our credentials, all we have to do is execute `eb deploy` (-v for verbose mode). This will package and deploy our code automatically based on the settings in our `config.yml`.
+    We're going to use the eb CLI to perform the deployment, since it comes pre-installed on the build image, and it takes care of a lot of the work for us.  Since we've manually added the config.yml, and our aws cli is already configured with our credentials, all we have to do is execute `eb deploy` (-v for verbose mode). This will package and deploy our code automatically based on the settings in our `config.yml`.
 
     Our job does following:
 
-    - Utilize the built-in `shippable_replace` utility on the `Dockerrun.aws.json` file as well as the `config.yml` file to replace placeholder with actual configuration.
-    - export the `IMAGE` env variable using the image resource environment variable.
+    - Utilize the built-in `shippable_replace` utility on the `Dockerrun.aws.json` file as well as the `config.yml` file to replace placeholders with the actual configuration.
+    - Export the `IMAGE` env variable using the image resource environment variable.
     - Make sure all inputs have `switch: off` except the image resources. We only want to deploy when the image changes.
 
 * **Required:** Yes.
@@ -232,7 +232,7 @@ Add the following yml block to your [shippable.jobs.yml](/platform/tutorial/work
 ```
 jobs:
   - name: deploy-eb-basic-deploy
-    type: runSH
+    type: runSh
     steps:
       - IN: deploy-eb-basic-image
       - IN: deploy-eb-nginx-image
@@ -244,7 +244,7 @@ jobs:
       - IN: deploy-eb-basic-repo
         switch: off
       - TASK:
-        - aws elasticbeanstalk describe-applications
+        - script: aws elasticbeanstalk describe-applications
         - script: pushd $DEPLOYEBBASICREPO_STATE/multi_container && ls -al
         - script: export IMAGE="${DEPLOYEBBASICIMAGE_SOURCENAME}:${DEPLOYEBBASICIMAGE_VERSIONNAME}"
         - script: shippable_replace Dockerrun.aws.json .elasticbeanstalk/config.yml
@@ -253,7 +253,7 @@ jobs:
 
 ##6. Import configuration into your Shippable account.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
 
 ##7. Trigger your pipeline
 

--- a/sources/deploy/aws-elastic-beanstalk-multiple-environments.md
+++ b/sources/deploy/aws-elastic-beanstalk-multiple-environments.md
@@ -5,7 +5,7 @@ sub_sub_section: AWS Elastic Beanstalk
 
 # Deploy single container to multiple AWS EB environments.
 
-The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring over your existing proven CLI based deployment scripts over to Shippable. This page walks through an example of using the Elastic Beanstalk (EB) CLI to deploy a single container application to multiple EB environments.
+The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring your existing proven CLI based deployment scripts over to Shippable. This page walks through an example of using the Elastic Beanstalk (EB) CLI to deploy a single container application to multiple EB environments.
 
 One common concept for multiple environments is having a beta environment that receives automatic deployments, and a production environment that is only deployed manually.  Each environment might need its own unique parameters and settings, and both environments are likely deploying to completely separate EB environments.
 
@@ -15,7 +15,7 @@ One common concept for multiple environments is having a beta environment that r
 
 ## Devops Assembly pipeline
 
-This is a pictorial representation of the workflow required to deploy your application. The green boxes are jobs and the grey boxes are the input resources for the jobs. Both jobs and inputs are specified in Shippable configuration files.
+This is a pictorial representation of the workflow required to deploy your application. The larger boxes are jobs and the smaller boxes are the input resources for the jobs. Both jobs and inputs are specified in Shippable configuration files.
 
 <img src="/images/deploy/elasticbeanstalk/eb-serial-envs.png" alt="Final Pipeline">
 
@@ -25,11 +25,11 @@ We will be defining the jobs and resources in a step by step manner below.
 
 They are four configuration files that are needed to achieve this usecase -
 
-* **[shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/):** Resources are defined in this file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* **[shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/):** Resources are defined in this file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* **[shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/):** Jobs are defined in this file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* **[shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/):** Jobs are defined in this file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
-* **`Dockerrun.aws.json`**: This file specifies the image and environment configuration. Placeholders are defined in this file for the image and environment configuration. These Placeholders give us flexibility to use the image and environment configuration that you will define in Shippable configuration files.
+* **`Dockerrun.aws.json`**: This file specifies the image and environment configuration. Placeholders are defined in this file for the image and environment configuration. These placeholders give us flexibility to use the image and environment configuration that you will define in Shippable configuration files.
 
 Content of [`Dockerrun.aws.json`](https://raw.githubusercontent.com/devops-recipes/deploy-beanstalk-basic/master/single_container/Dockerrun.aws.json)
 ```
@@ -93,7 +93,7 @@ global:
 
 Inside `config.yml`, you will see placeholders defined for application, environment and region. These placeholders will be replaced dynamically with your Shippable configuration giving you tremendous flexibility and reuse.
 
-## Prequisites
+## Prerequisites
 
 ### Create a Beanstalk application and environment
 
@@ -128,7 +128,7 @@ resources:
 
 ###2. Define `deploy-eb-basic-config`.
 
-* **Description:** `deploy-eb-basic-config` is a [cliConfig](/platform/workflow/resource/cliconfig/#cliconfig) resource that references credentials needed to setup a CLI for EB.
+* **Description:** `deploy-eb-basic-config` is a [cliConfig](/platform/workflow/resource/cliconfig/) resource that references credentials needed to setup a CLI for EB.
 
 * **Required:** Yes.
 
@@ -154,7 +154,7 @@ resources:
 
 ###3. Define `deploy-eb-basic-params` and `prod-params`
 
-* **Description:** `deploy-eb-basic-params` and `prod-params` are [params](/platform/workflow/resource/params/#params) resources that define variables we want to make easily configurable. These variables definitions replace the placeholders in the `Docker.aws.json` and `config.yml` files. Furthermore, these params are environment specific allowing each environment to be customized.
+* **Description:** `deploy-eb-basic-params` and `prod-params` are [params](/platform/workflow/resource/params/) resources that define variables we want to make easily configurable. These variables definitions replace the placeholders in the `Dockerrun.aws.json` and `config.yml` files. Furthermore, these params are environment specific allowing each environment to be customized.
 
 * **Required:** Yes.
 
@@ -182,7 +182,7 @@ resources:
         AWS_EB_ENVIRONMENT_SINGLE: "prod"
 ```
 
-* **Description:** `deploy-eb-basic-params` is a [params](/platform/workflow/resource/params/#params) resource the defines variables we want to make easily configurable. These variables definitions replace the placeholders in the `Docker.aws.json` and `config.yml` files.
+* **Description:** `deploy-eb-basic-params` is a [params](/platform/workflow/resource/params/) resource that defines variables we want to make easily configurable. These variables definitions replace the placeholders in the `Dockerrun.aws.json` and `config.yml` files.
 
 * **Required:** Yes.
 
@@ -203,7 +203,7 @@ Add the following yml block to your [shippable.resources.yml](/platform/tutorial
 
 ###4. Define `deploy-eb-basic-repo`
 
-* **Description:** `deploy-eb-basic-repo` is a [gitRepo](/platform/workflow/resource/gitrepo/#gitrepo) resource which represents the repository of our application that has all the source and the configuration files we created earlier. We need this resource to access and replace content dynamically in the `Docker.aws.json` and `config.yml` files.  
+* **Description:** `deploy-eb-basic-repo` is a [gitRepo](/platform/workflow/resource/gitrepo/) resource which represents our application repository that has all the source and the configuration files we created earlier. We need this resource to access and replace content dynamically in the `Dockerrun.aws.json` and `config.yml` files.  
 
 * **Required:** Yes.
 
@@ -223,11 +223,11 @@ resources:
 
 ###5. Define `deploy-beta` and `deploy-prod`
 
-* **Description:** `deploy-beta` and `deploy-prod` are [runSH](/platform/workflow/job/runsh/) jobs that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted.
+* **Description:** `deploy-beta` and `deploy-prod` are [runSh](/platform/workflow/job/runsh/) jobs, which let you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted.
 
     A couple of points to note:
 
-    - We Utilize the built-in `shippable_replace` utility on the `Dockerrun.aws.json` file as well as the `config.yml` file to replace placeholder with actual configuration.
+    - We utilize the built-in `shippable_replace` utility on the `Dockerrun.aws.json` file as well as the `config.yml` file to replace placeholders with the actual configuration.
     - We export the `IMAGE` env variable using the image resource environment variable in the beta job.
     - To ensure that the same image is deployed to production, we store the image tag in the job state of the `deploy-beta` job and use it in the `deploy-prod` job.
     - All the inputs of the `deploy-prod` are switched off, since we want to manually trigger prod deployment.
@@ -283,7 +283,7 @@ We use the ebcli to perform the deployment, since it comes pre-installed on the 
 
 ###6. Import configuration into your Shippable account.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
 
 ###7. Trigger your pipeline
 

--- a/sources/deploy/aws-elastic-beanstalk-state-env-vars.md
+++ b/sources/deploy/aws-elastic-beanstalk-state-env-vars.md
@@ -15,9 +15,9 @@ Shippable does not support managed beanstalk deployments at this time.
 
 ## Unmanaged
 
-In an unmanaged scenario, you'll be using a runCLI job with an AWS cliConfig.
+In an unmanaged scenario, you'll be using a runSh job with an AWS cliConfig.
 
-Managing state and utilizing ENVs is a critical part of writing robust runCLI and runSh scripts. This section will explain how these are used in the sample project.
+Managing state and utilizing ENVs is a critical part of writing robust runSh scripts. This section will explain how these are used in the sample project.
 
 First, lets look at our application image.  This image will be updated automatically via Shippable CI.  You can check the [documentation](../ci/trigger-pipeline-jobs) for instructions on how to configure a shippable.yml to accomplish that.
 
@@ -32,12 +32,12 @@ resources:
       versionName: "latest"
 ```
 
-Now we should add this image as an IN to our runCLI job.
+Now we should add this image as an IN to our runSh job.
 
 ```
 jobs:
   - name: deploy-eb-basic-deploy
-    type: runCLI
+    type: runSh
     steps:
       - IN: deploy-eb-basic-image
       - TASK:
@@ -47,7 +47,7 @@ jobs:
 
 ### Environment Variables
 
-By adding resources as `IN` steps, we have automatic access to several environment variables that will be useful for writing generic scripts.  Let's look at an excerpt of a printenv from this runCLI job so that we can see what is available.
+By adding resources as `IN` steps, we have automatic access to several environment variables that will be useful for writing generic scripts.  Let's look at an excerpt of a printenv from this runSh job so that we can see what is available.
 
 Resource-specific ENVs always start with the resource name. Job specific ENVs always start with the word `JOB`.  Shippable-added ENVs are always in all caps.
 
@@ -136,11 +136,11 @@ For example, lets say you want to update an environment variable in your applica
         AWS_EB_BUCKET_NAME: "shippable-deploy-eb"
 ```
 
-Then add it as an OUT of one runCLI job that determines what the value should be, like this:
+Then add it as an OUT of one runSh job that determines what the value should be, like this:
 
 ```
 name: MyLoadChecker
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
   - IN: MyECSCluster
@@ -157,7 +157,7 @@ Now, you'll want a second job that uses the `params` resource as an IN step.
 
 ```
 name: MyBeanstalkUpdater
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
   - IN: deploy-eb-env-params
@@ -197,7 +197,7 @@ Finally, make sure that your JSON file follows the correct Dockerrun.aws.json fo
 
 ```
 
-`shippable_replace` will automatically replace the variables with the values in the environment.  Then, when you send the package to beanstalk, it will deploy the dockerrun with the replaced values.
+`shippable_replace` will automatically replace the variables with the values in the environment.  Then, when you send the package to beanstalk, it will deploy the Dockerrun.aws.json with the replaced values.
 
 ### Job State Management
 
@@ -205,14 +205,14 @@ You don't have to rely on other resources to transfer information from one job t
 
 Instead of writing to a `<resourceName>.env` file, just write any file you want to that same state directory, and use the job itself as input to the next job.
 
-Here's an example of a runCLI job that takes another job as IN, and references the previous job's state directory.
+Here's an example of a runSh job that takes another job as IN, and references the previous job's state directory.
 
 ```
 name: MyBeanstalkDeployer
-type: runCLI
+type: runSh
 steps:
   - IN: MyAwsConfig
-  - IN: MyLoadChecker  #another runCLI job
+  - IN: MyLoadChecker  #another runSh job
   - TASK:
     - script: ls $MYLOADCHECKER_STATE
     - script: JSON_FILE=$MYLOADCHECKER_STATE/single_container/Dockerrun.aws.json

--- a/sources/deploy/aws-elastic-beanstalk.md
+++ b/sources/deploy/aws-elastic-beanstalk.md
@@ -5,7 +5,7 @@ sub_sub_section: AWS Elastic Beanstalk
 
 # Deploy single container to a single AWS EB environment.
 
-The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring over your existing proven CLI based deployment scripts over to Shippable.  This page walks through an example of using the Elastic Beanstalk (EB) CLI to deploy a single container application to your EB environment.
+The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring your existing proven CLI based deployment scripts over to Shippable.  This page walks through an example of using the Elastic Beanstalk (EB) CLI to deploy a single container application to your EB environment.
 
 ## Topics Covered
 
@@ -23,11 +23,11 @@ We will be defining the jobs and resources in a step by step manner below.
 
 They are four configuration files that are needed to achieve this usecase -
 
-* **[shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/):** Resources are defined in this file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* **[shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/):** Resources are defined in this file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* **[shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/):** Jobs are defined in this file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* **[shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/):** Jobs are defined in this file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
-* **`Dockerrun.aws.json`**: This file specifies the image and environment configuration. Placeholders are defined in this file for the image and environment configuration. These Placeholders give us flexibility to use the image and environment configuration that you will define in Shippable configuration files.
+* **`Dockerrun.aws.json`**: This file specifies the image and environment configuration. Placeholders are defined in this file for the image and environment configuration. These placeholders give us flexibility to use the image and environment configuration that you will define in Shippable configuration files.
 
 Content of [`Dockerrun.aws.json`](https://raw.githubusercontent.com/devops-recipes/deploy-beanstalk-basic/master/single_container/Dockerrun.aws.json)
 ```
@@ -89,9 +89,9 @@ global:
   workspace_type: Application
 ```
 
-Inside `config.yml`, you will see placeholders defined for application, environment and region. These placeholders will be replaced dynamically with your Shippable configuration giving you tremendous flexibility and reuse.
+Inside `config.yml`, you will see placeholders defined for application, environment, and region. These placeholders will be replaced dynamically with your Shippable configuration giving you tremendous flexibility and reuse.
 
-## Prequisites
+## Prerequisites
 
 ### Create a Beanstalk application and environment
 
@@ -126,7 +126,7 @@ resources:
 
 ###2. Define `deploy-eb-basic-config`.
 
-* **Description:** `deploy-eb-basic-config` is a [cliConfig](/platform/workflow/resource/cliconfig/#cliconfig) resource that references credentials needed to setup a CLI for EB.
+* **Description:** `deploy-eb-basic-config` is a [cliConfig](/platform/workflow/resource/cliconfig/) resource that references credentials needed to setup a CLI for EB.
 
 * **Required:** Yes.
 
@@ -153,7 +153,7 @@ resources:
 
 ###3. Define `deploy-eb-basic-params`
 
-* **Description:** `deploy-eb-basic-params` is a [params](/platform/workflow/resource/params/#params) resource that defines variables we want to make easily configurable. These variables definitions replace the placeholders in the `Docker.aws.json` and `config.yml` files.
+* **Description:** `deploy-eb-basic-params` is a [params](/platform/workflow/resource/params/) resource that defines variables we want to make easily configurable. These variables definitions replace the placeholders in the `Dockerrun.aws.json` and `config.yml` files.
 
 * **Required:** Yes.
 
@@ -176,7 +176,7 @@ resources:
 
 ###4. Define `deploy-eb-basic-repo`
 
-* **Description:** `deploy-eb-basic-repo` is a [gitRepo](/platform/workflow/resource/gitrepo/#gitrepo) resource which represents the repository of our application that has all the source and the configuration files we created earlier. We need this resource to access and replace content dynamically in the `Docker.aws.json` and `config.yml` files.  
+* **Description:** `deploy-eb-basic-repo` is a [gitRepo](/platform/workflow/resource/gitrepo/) resource which represents our application repository that has all the source and the configuration files we created earlier. We need this resource to access and replace content dynamically in the `Dockerrun.aws.json` and `config.yml` files.  
 
 * **Required:** Yes.
 
@@ -197,14 +197,14 @@ resources:
 
 ###5. Define `deploy-eb-basic-deploy`
 
-* **Description:** `deploy-eb-basic-deploy` is a [runSH](/platform/workflow/job/runsh/) job that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted.
+* **Description:** `deploy-eb-basic-deploy` is a [runSh](/platform/workflow/job/runsh/) job that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted.
 
     We're going to use the ebcli to perform the deployment, since it comes pre-installed on the build image, and it takes care of a lot of the work for us.  Since we've manually added the config.yml, and our aws cli is already configured with our credentials, all we have to do is execute `eb deploy` (-v for verbose mode). This will package and deploy our code automatically based on the settings in our `config.yml`.
 
     Our job does following:
 
     - Utilize the built-in `shippable_replace` utility on the `Dockerrun.aws.json` file as well as the `config.yml` file to replace placeholder with actual configuration.
-    - export the `IMAGE` env variable using the image resource environment variable.
+    - Export the `IMAGE` env variable using the image resource environment variable.
     - Make sure all inputs have `switch: off` except the image resources. We only want to deploy when the image changes.
 
 * **Required:** Yes.
@@ -217,7 +217,7 @@ Add the following yml block to your [shippable.jobs.yml](/platform/tutorial/work
 jobs:
 
   - name: deploy-eb-basic-deploy
-    type: runSH
+    type: runSh
     steps:
       - IN: deploy-eb-basic-image
       - IN: deploy-eb-basic-config
@@ -227,7 +227,7 @@ jobs:
       - IN: deploy-eb-basic-repo
         switch: off
       - TASK:
-        - aws elasticbeanstalk describe-applications
+        - script: aws elasticbeanstalk describe-applications
         - script: pushd $DEPLOYEBBASICREPO_STATE/single_container && ls -al
         - script: export IMAGE="${DEPLOYEBBASICIMAGE_SOURCENAME}:${DEPLOYEBBASICIMAGE_VERSIONNAME}"
         - script: shippable_replace Dockerrun.aws.json .elasticbeanstalk/config.yml
@@ -236,7 +236,7 @@ jobs:
 
 ##6. Import configuration into your Shippable account.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
 
 ##7. Trigger your pipeline
 

--- a/sources/deploy/deploy-amazon-ecs-cloud-native-cli.md
+++ b/sources/deploy/deploy-amazon-ecs-cloud-native-cli.md
@@ -4,7 +4,7 @@ sub_section: Deploy using Cloud Native CLI
 
 # Deploying to Amazon ECS using cloud-native CLI
 
-The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring over your existing proven CLI based deployment scripts over to Shippable.  This page walks through an example of using the AWS CLI to  deploy a docker image to one ECS cluster.
+The [deploy job](/platform/workflow/job/deploy) helps make your deployments very easy and quick to configure. However, you might want to write your deployment scripts yourself for added control and customization or simply to bring your existing proven CLI based deployment scripts over to Shippable.  This page walks through an example of using the AWS CLI to deploy a Docker image to one ECS cluster.
 
 ## Topics Covered
 
@@ -16,21 +16,21 @@ The [deploy job](/platform/workflow/job/deploy) helps make your deployments very
 
 They are two configuration files that are needed to achieve this usecase -
 
-* Resources are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* Resources are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* Jobs are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* Jobs are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
 ## Steps
 
 ###1. Define `app_image`.
 
-* **Description:** `app_image` represents your Docker image in your pipeline. In our example, we're using an image hosted on Docker hub.
+* **Description:** `app_image` represents your Docker image in your pipeline. In our example, we're using an image hosted on Docker Hub.
 * **Required:** Yes.
 * **Integrations needed:** Docker Hub, or any [supported Docker registry](/platform/integration/overview/#supported-docker-registry-integrations).
 
 **Steps**  
 
-1. Create an account integration using your Shippable account for your docker registry.
+1. Create an account integration using your Shippable account for your Docker registry.
     Instructions to create an integration can be found [here](http://docs.shippable.com/platform/tutorial/integration/howto-crud-integration/). Copy the friendly name of the integration.
 
 2. Add the following yml block to your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file.
@@ -48,7 +48,7 @@ They are two configuration files that are needed to achieve this usecase -
 
 ###2. Define `app_gitRepo`.
 
-* **Description:** `app_gitRepo` is a [gitRepo](/platform/workflow/resource/gitrepo/#gitrepo) resource which is a pointer to the git repository that contains your cli scripts.
+* **Description:** `app_gitRepo` is a [gitRepo](/platform/workflow/resource/gitrepo/) resource which is a pointer to the git repository that contains your cli scripts.
 * **Required:** Yes.
 * **Integrations needed:** default SCM account integration or other source control providers.
 
@@ -58,7 +58,7 @@ If your CLI repository is on another SCM account, create an integration for it b
 
 - [GitHub]([instructions here](/platform/integration/github/))
 - [Bitbucket](/platform/integration/bitbucket/)
-- [Gitlab](/platform/integration/gitlab/)
+- [GitLab](/platform/integration/gitlab/)
 - [GitHub Enterprise](/platform/integration/github-enterprise/)
 
 **Steps**  
@@ -81,7 +81,7 @@ resources:
 
 ###3. Define `app_cliConfig`.
 
-* **Description:** `app_cliConfig` is a [cliConfig](/platform/workflow/resource/cliconfig/#cliconfig) resource used to store configuration information needed to setup a CLI for your orchestration platform.
+* **Description:** `app_cliConfig` is a [cliConfig](/platform/workflow/resource/cliconfig/) resource used to store configuration information needed to setup a CLI for your orchestration platform.
 * **Required:** Yes.
 * **Integrations needed:** AWS. The complete list of supported CLI integrations can be found [here](/platform/workflow/resource/cliconfig/#configured-cli-tools).
 
@@ -137,7 +137,7 @@ ${APP_IMAGE_SOURCENAME} and ${APP_IMAGE_VERSIONNAME} are variables that will get
 
 ###5. Define `app_cli_job`.
 
-* **Description:** `app_cli_job` is a [runSH](/platform/workflow/job/runsh/) job that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted. Note that we have set `switch: off` for `app_gitRepo` since we do not want to trigger the runSH job every time a commit occurs on the repo. We want the runSH job to trigger only after the container image has been built.s
+* **Description:** `app_cli_job` is a [runSh](/platform/workflow/job/runsh/) job that lets you run any shell script as part of your DevOps Assembly Line. It is one of the most versatile jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted. Note that we have set `switch: off` for `app_gitRepo` since we do not want to trigger the runSh job every time a commit occurs on the repo. We want the runSh job to trigger only after the container image has been built.
 
 * **Required:** Yes.
 
@@ -148,7 +148,7 @@ Add the following yml block to your [shippable.jobs.yml](/platform/tutorial/work
 ```
 jobs:
   - name: app_cli_job
-    type: runSH
+    type: runSh
     steps:
       - IN: app_image
       - IN: app_gitRepo
@@ -165,13 +165,13 @@ jobs:
 The snippet above does the following:
 
 - Uses `shippable_replace` utility to fill in environment variables for our task definition template.
-- Register a new task definition on Amazon ECS based on our json file using the AWS CLI.
-- Captures the revision number from the output, store it in the ENV, and echo it to the console.
+- Registers a new task definition on Amazon ECS based on our json file using the AWS CLI.
+- Captures the revision number from the output, stores it in the ENV, and echos it to the console.
 - Updates the service using the `--task-definition family:revision` syntax.
 
 ##6. Import the configuration into your Shippable account to create the assembly line for the application.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/). You can then follow instructions to [add your assembly line to Shippable](/platform/tutorial/workflow/crud-syncrepo/).
 
 ##7. Trigger your pipeline
 
@@ -180,6 +180,6 @@ When you're ready for deployment, right-click on the `app_cli_job` job in the [S
 ## Sample project
 
 Here are some links to a working sample of this scenario. This is a simple Node.js application that runs some tests and then pushes
-the image to Amazon ECR. It also contains all of the pipelines configuration files for deploying to Amazon ECS via runCLI job.
+the image to Amazon ECR. It also contains all of the pipelines configuration files for deploying to Amazon ECS via runSh job.
 
 **Source code:**  [devops-recipes/deploy-ecs-unmanaged](https://github.com/devops-recipes/deploy-ecs-unmanaged)

--- a/sources/deploy/deploy-cloud-native-overview.md
+++ b/sources/deploy/deploy-cloud-native-overview.md
@@ -4,7 +4,7 @@ sub_section: Deploy using Cloud Native CLI
 
 # Deployments using cloud-native CLI
 
-Most applications today run in the Cloud. Each cloud provider has a native CLI.
+Most applications today run in the cloud. Each cloud provider has a native CLI.
 
 Shippable platform offers very rich support for CLI's by:
 
@@ -30,10 +30,10 @@ Here is a list of CLIs and their specific versions that we have available as par
 
 ## Initializing the CLI runtime
 
-Shippable platform automatically initializes the CLI runtime with your credentials securely. This allows you to focus more on the CLI commands than credentials management and initializing your CLI everytime you need to use it. To learn more, see our CLI tutorials below.
+Shippable platform automatically initializes the CLI runtime with your credentials securely. This allows you to focus more on the CLI commands than credentials management and initializing your CLI every time you need to use it. To learn more, see our CLI tutorials below.
 
 ## Further Reading
 
-* [Using the AWS CLI to deploy to ECS](/deploy/cd_with_cloud_native_cli)
-* [runSH job](/platform/workflow/job/runsh/)
-* [cliConfig](/platform/workflow/resource/cliconfig/#cliconfig) resource.
+* [Using the AWS CLI to deploy to ECS](/deploy/deploy-amazon-ecs-cloud-native-cli)
+* [runSh job](/platform/workflow/job/runsh/)
+* [cliConfig](/platform/workflow/resource/cliconfig/) resource.

--- a/sources/deploy/deploy-to-gke-using-gcloud-cli.md
+++ b/sources/deploy/deploy-to-gke-using-gcloud-cli.md
@@ -16,12 +16,12 @@ resources:
     type: cliConfig
     integration: MyGKECredentials
 ```
-For more details on the `cliConfig` resource, [see here](../platform/workflow/resource/cliconfig). Now you'll need a particular job that can utilize that resource
+For more details on the `cliConfig` resource, [see here](../platform/workflow/resource/cliconfig). Now you'll need a job that can utilize that resource.
 
 ```
 jobs:
   - name: myCustomDeployment
-    type: runCLI
+    type: runSh
     steps:
       - IN: MyGkeConfig
       - TASK:
@@ -56,7 +56,7 @@ Now, update the job to use this gitRepo as an `IN`, and add some extra commands 
 ```
 jobs:
   - name: myCustomDeployment
-    type: runCLI
+    type: runSh
     steps:
       - IN: MyAwsConfig
       - IN: MyPodSpecRepo
@@ -92,4 +92,4 @@ spec:
 
 ```
 
-The `runCLI` job will automatically configure kubectl based on the json key associated with your GKE integration.  This means that you don't have to do any setup yourself. Your script can be focused on the actions you want to take.  In this case, we are creating a new replication controller in the `shippable` namespace to run our sample app and expose it on port 80.
+The `runSh` job will automatically configure kubectl based on the json key associated with your GKE integration.  This means that you don't have to do any setup yourself. Your script can be focused on the actions you want to take.  In this case, we are creating a new replication controller in the `shippable` namespace to run our sample app and expose it on port 80.

--- a/sources/deploy/gke-custom-pods.md
+++ b/sources/deploy/gke-custom-pods.md
@@ -74,6 +74,6 @@ resources:
 ```
 ## Unmanaged
 
-In an unmanaged scenario, you'll be using a runCLI job with a GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
+In an unmanaged scenario, you'll be using a runSh job with a GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
 
-If you've completed the basic scenario, you've already done everything required to support these options.  Just update your replicationController.yaml to include any additional settings you'd like, and update your cluster via `kubectl` commands. Refer directly to the kubernetes documentation for all possible available options.
+If you've completed the basic scenario, you've already done everything required to support these options.  Just update your replicationController.yaml to include any additional settings you'd like, and update your cluster via `kubectl` commands. Refer directly to the Kubernetes documentation for all possible available options.

--- a/sources/deploy/gke-multiple-containers.md
+++ b/sources/deploy/gke-multiple-containers.md
@@ -247,9 +247,9 @@ You'll see in the logs that each manifest is deployed in turn, and the deploy jo
 
 ## Unmanaged Deployments
 
-In an unmanaged scenario, you'll be using a runCLI job with an GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
+In an unmanaged scenario, you'll be using a runSh job with an GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
 
-For unamanged jobs, the deployment workflow is under your control, but here is a description of how shippable treats different scenarios in the managed jobs.  You can duplicate this functionlity in your own scripts and even discover ways of improving the logic.
+For unamanged jobs, the deployment workflow is under your control, but here is a description of how shippable treats different scenarios in the managed jobs.  You can duplicate this functionality in your own scripts and even discover ways of improving the logic.
 
 two manifests into a single deploy job:
 

--- a/sources/deploy/gke-multiple-environments.md
+++ b/sources/deploy/gke-multiple-environments.md
@@ -89,7 +89,7 @@ resources:
       namespace: "prod"
 
 ```
-Notice how the cluster is actually the same, but the namespace field has changed. This is the recommended way to create separation on kubernetes.  Namespaces are isolated, so it's rarely necessary to create extra clusters.
+Notice how the cluster is actually the same, but the namespace field has changed. This is the recommended way to create separation on Kubernetes.  Namespaces are isolated, so it's rarely necessary to create extra clusters.
 
 Finally, lets add two deploy jobs. The first one (beta) should take the beta params, beta cluster, and the manifest as `IN` statements.  The second deploy job (prod) should take the beta deploy job, prod params, and prod cluster as `IN` statements.
 
@@ -253,6 +253,6 @@ Now, switch back to your SPOG view, right-click the production deploy job, and c
 
 ## Unmanaged deployments
 
-In an unmanaged scenario, you'll be using a runCLI job with a GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
+In an unmanaged scenario, you'll be using a runSh job with a GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
 
 For unmanaged jobs, you can run your kubectl and gcloud commands against any cluster and region that you want.

--- a/sources/deploy/gke-strategy.md
+++ b/sources/deploy/gke-strategy.md
@@ -168,6 +168,6 @@ Depending on how many manifests you're deploying, you should notice a significan
 
 ## Unmanaged Deployments
 
-In an unmanaged scenario, you'll be using a runCLI job with a GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
+In an unmanaged scenario, you'll be using a runSh job with a GKE cliConfig [as described in the unmanaged section of our basic scenario](./gke#unmanaged-deployments).
 
 From that starting point, there are no pre-built deployment strategies for GKE for unmanaged jobs, however the power and flexibility of Shippable Assembly Lines is available to you to script whatever deployment behavior works best for your environment.

--- a/sources/deploy/howto-configure-deploy-envs.md
+++ b/sources/deploy/howto-configure-deploy-envs.md
@@ -2,7 +2,7 @@ main_section: Deploy
 sub_section: How To
 
 # Scenarios
-These are the following use cases that will be covered in this tutotial
+These are the following use cases that will be covered in this tutorial
 
 * Deploying a Docker container to an orchestration service and setting up environment variables during deployment
 * Multi-stage Continuous Delivery of a Docker container through Dev, Test & Prod environments and dynamically changing the environment variables as the container moves through the delivery workflow
@@ -37,8 +37,8 @@ For example, if you want to use different environment parameters (say database s
 
 In the picture above, `deploy-test` takes `params-1` as an input. After testing, a release is created with the `release` job. This triggers production deployment with the `deploy-prod` job, which takes `params-2` as an input. For this production deployment, we will use a superset of settings from `params-1` and `params-2`, with values for any common settings being chosen from `params-2`.
 
-## Using params resources as inputs to runSh and runCLI jobs
-If a params resource is added as an input, the key-value pairs contained in the params resource are set as environment variables in the runSh or runCLI job. The variables can be used by
+## Using params resources as inputs to runSh jobs
+If a params resource is added as an input, the key-value pairs contained in the params resource are set as environment variables in the runSh job. The variables can be used by
 
 - following the naming convention for those variables available in the documentation on [runSh environment variables](/platform/workflow/job/runsh/#resource-variables).
 - directly using the variable name. If there are multiple params resources as INs to the runSh/runCI jobs and if there are keys shared across the params resources, then the last value of that key will be used. This works similar to Bash export of variables.

--- a/sources/deploy/vm-basic.md
+++ b/sources/deploy/vm-basic.md
@@ -28,13 +28,13 @@ We will now proceed to implementing the jobs and resources in the workflow.
 
 They are two configuration files that are needed to achieve this usecase -
 
-* Resources (grey boxes) are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* Resources (grey boxes) are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* Jobs (green boxes) are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* Jobs (green boxes) are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
 These files should be committed to your source control. Step 6 of the workflow below will describe how to add the config to Shippable.
 
-## Prequisites for VMs
+## Prerequisites for VMs
 
 Since we are deploying and running a NodeJS application, preinstall nodejs, npm, and forever on each VM host.
 
@@ -42,7 +42,7 @@ Since we are deploying and running a NodeJS application, preinstall nodejs, npm,
 
 ###1. Define `app_file`
 
-* **Description:** `app_file` is an [file resource](/platform/workflow/resource/file/#file) resource that points to the URL of your application package. In our example, we're hosting the application in an public AWS S3 bucket with object versioning.
+* **Description:** `app_file` is an [file resource](/platform/workflow/resource/file/) resource that points to the URL of your application package. In our example, we're hosting the application in an public AWS S3 bucket with object versioning.
 * **Required:** Yes.
 
 **Steps**
@@ -83,7 +83,7 @@ resources:
 
 ###3. Define `app_service_def`.
 
-* **Description:** `app_service_def` is a [manifest](/platform/workflow/job/manifest) job used to create a service definition of a deployable unit of your application. The service definition consists of the application package and environment. The definition is also versioned (any change to the inputs of the manifest creates a new semantic version of the manifest) and is immutable.
+* **Description:** `app_service_def` is a [manifest](/platform/workflow/job/manifest) job used to create a service definition of a deployable unit of your application. The service definition consists of the application package and environment. The definition is also versioned (any change to the inputs of the manifest creates a new version of the manifest) and is immutable.
 * **Required:** Yes.
 
 **Steps**
@@ -101,10 +101,10 @@ jobs:
 
 ###4. Define `app_cluster`.
 
-* **Description:** `app_cluster` is a [cluster](/platform/integration/node-cluster) resource that represents the VM cluster where your application is deployed to. In our example, the cluster points to two AWS EC2 machines.
+* **Description:** `app_cluster` is a [cluster](/platform/integration/node-cluster) resource that represents the VM cluster where your application is deployed. In our example, the cluster points to two AWS EC2 machines.
 * **Required:** Yes.
 * **Integrations needed:** [Node Cluster](/platform/integration/node-cluster/)
-In this integration, we specify the public IP addresses of all the VMs where we want to deploy the application to.
+In this integration, we specify the public IP addresses of all the VMs where we want to deploy the application.
 
 **Steps**
 
@@ -163,7 +163,7 @@ jobs:
 
 ###6. Import configuration into your Shippable account.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/).
 
 Follow [these instructions](/platform/tutorial/workflow/crud-syncrepo/) to import your configuration files into your Shippable account.
 

--- a/sources/deploy/vm-jfrog.md
+++ b/sources/deploy/vm-jfrog.md
@@ -29,13 +29,13 @@ We will now proceed to implementing the jobs and resources in the workflow.
 
 They are two configuration files that are needed to achieve this usecase -
 
-* Resources (grey boxes) are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* Resources (grey boxes) are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* Jobs (green boxes) are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* Jobs (green boxes) are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
 These files should be committed to your source control. Step 6 of the workflow below will describe how to add the config to Shippable.
 
-## Prequisites for VMs
+## Prerequisites for VMs
 
 Since we are deploying and running a NodeJS application, preinstall nodejs, npm, and forever on each VM host.
 
@@ -43,7 +43,7 @@ Since we are deploying and running a NodeJS application, preinstall nodejs, npm,
 
 ###1. Define `app_file`
 
-* **Description:** `app_file` is an [file resource](/platform/workflow/resource/file/#file) resource that points to the URL of your application package. In our example, we're hosting the application in an public AWS S3 bucket with object versioning.
+* **Description:** `app_file` is an [file resource](/platform/workflow/resource/file/) resource that points to the URL of your application package. In our example, we're hosting the application in an public AWS S3 bucket with object versioning.
 * **Required:** Yes.
 * **Integrations needed:** [JFrog Artifactory](/platform/integration/jfrog-artifactory/)
 
@@ -90,7 +90,7 @@ resources:
 
 ###3. Define `app_service_def`.
 
-* **Description:** `app_service_def` is a [manifest](/platform/workflow/job/manifest) job used to create a service definition of a deployable unit of your application. The service definition consists of the application package and environment. The definition is also versioned (any change to the inputs of the manifest creates a new semantic version of the manifest) and is immutable.
+* **Description:** `app_service_def` is a [manifest](/platform/workflow/job/manifest) job used to create a service definition of a deployable unit of your application. The service definition consists of the application package and environment. The definition is also versioned (any change to the inputs of the manifest creates a new version of the manifest) and is immutable.
 * **Required:** Yes.
 
 **Steps**
@@ -108,10 +108,10 @@ jobs:
 
 ###4. Define `app_cluster`.
 
-* **Description:** `app_cluster` is a [cluster](/platform/integration/node-cluster) resource that represents the VM cluster where your application is deployed to. In our example, the cluster points to two AWS EC2 machines.
+* **Description:** `app_cluster` is a [cluster](/platform/integration/node-cluster) resource that represents the VM cluster where your application is deployed. In our example, the cluster points to two AWS EC2 machines.
 * **Required:** Yes.
 * **Integrations needed:** [Node Cluster](/platform/integration/node-cluster/)
-In this integration, we specify the public IP addresses of all the VMs where we want to deploy the application to.
+In this integration, we specify the public IP addresses of all the VMs where we want to deploy the application.
 
 **Steps**
 
@@ -162,16 +162,15 @@ jobs:
 
 ```
 
-  In this case, we know that files are copied to a specific location on the host, and that is the `/tmp/shippable` directory.  From that point, there will be a directory named after the `deploy` job, and one or more directories inside that folder named for each manifest being deployed.  In this case, we're using the names of our resources to build the path to the downloaded file.
+In this case, we know that files are copied to a specific location on the host, and that is the `/tmp/shippable` directory.  From that point, there will be a directory named after the `deploy` job, and one or more directories inside that folder named for each manifest being deployed.  In this case, we're using the names of our resources to build the path to the downloaded file.
 
-  Since our application is written in nodejs, we're using foreverjs to run the process in the background.  After extracting our package, we stop any existing running forever scripts, and then we start our application.
+Since our application is written in nodejs, we're using foreverjs to run the process in the background.  After extracting our package, we stop any existing running forever scripts, and then we start our application.
 
-  **You'll need to make sure your host machines have pre-installed all of the applications necessary to run your software.  In our case, we've pre-installed nodejs, npm, and forever on each host.**
-
+**You'll need to make sure your host machines have pre-installed all of the applications necessary to run your software.  In our case, we've pre-installed nodejs, npm, and forever on each host.**
 
 ###6. Import configuration into your Shippable account.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/).
 
 Follow [these instructions](/platform/tutorial/workflow/crud-syncrepo/) to import your configuration files into your Shippable account.
 

--- a/sources/deploy/vm-multiple-environments.md
+++ b/sources/deploy/vm-multiple-environments.md
@@ -42,13 +42,13 @@ We will now proceed to implementing the jobs and resources in the workflow.
 
 They are two configuration files that are needed to achieve this usecase -
 
-* Resources (grey boxes) are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file, that should be created at the root of your repository. Please find an overview of resources [here](/platform/workflow/resource/overview/).
+* Resources (grey boxes) are defined in your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file. Please find an overview of resources [here](/platform/workflow/resource/overview/).
 
-* Jobs (green boxes) are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file, that should be created at the root of your repository. Please find an overview of jobs [here](/platform/workflow/job/overview/).
+* Jobs (green boxes) are defined in your [shippable.jobs.yml](/platform/tutorial/workflow/shippable-jobs-yml/) file. Please find an overview of jobs [here](/platform/workflow/job/overview/).
 
 These files should be committed to your source control. Step 6 of the workflow below will describe how to add the config to Shippable.
 
-## Prequisites for VMs
+## Prerequisites for VMs
 
 Since we are deploying and running a NodeJS application, preinstall nodejs, npm, and forever on each VM host.
 
@@ -56,7 +56,7 @@ Since we are deploying and running a NodeJS application, preinstall nodejs, npm,
 
 ###1. Define `app_file`
 
-* **Description:** `app_file` is an [file resource](/platform/workflow/resource/file/#file) resource that points to the URL of your application package. In our example, we're hosting the application in an public AWS S3 bucket with object versioning.
+* **Description:** `app_file` is an [file resource](/platform/workflow/resource/file/) resource that points to the URL of your application package. In our example, we're hosting the application in an public AWS S3 bucket with object versioning.
 * **Required:** Yes.
 
 **Steps**
@@ -102,7 +102,7 @@ resources:
 
 ###3. Define `app_service_def`.
 
-* **Description:** `app_service_def` is a [manifest](/platform/workflow/job/manifest) job used to create a service definition of a deployable unit of your application. The service definition consists of the application package resource. The definition is also versioned (any change to the inputs of the manifest creates a new semantic version of the manifest) and is immutable.
+* **Description:** `app_service_def` is a [manifest](/platform/workflow/job/manifest) job used to create a service definition of a deployable unit of your application. The service definition consists of the application package resource. The definition is also versioned (any change to the inputs of the manifest creates a new version of the manifest) and is immutable.
 * **Required:** Yes.
 
 **Steps**
@@ -120,10 +120,10 @@ jobs:
 
 ###4. Define `app_beta_cluster` and `app_prod_cluster`.
 
-* **Description:** `app_beta_cluster` and `app_prod_cluster` are [cluster](/platform/integration/node-cluster) resources that represents the dev and prod VM clusters where your application will be deployed to. In our example, each cluster resource points to two AWS EC2 machines.
+* **Description:** `app_beta_cluster` and `app_prod_cluster` are [cluster](/platform/integration/node-cluster) resources that represents the dev and prod VM clusters where your application will be deployed. In our example, each cluster resource points to two AWS EC2 machines.
 * **Required:** Yes.
 * **Integrations needed:** [Node Cluster](/platform/integration/node-cluster/)
-In this integration, we specify the public IP addresses of all the VMs where we want to deploy the application to.
+In this integration, we specify the public IP addresses of all the VMs where we want to deploy the application.
 
 **Steps**
 
@@ -149,7 +149,7 @@ resources:
 
 * **Description:** `app_beta_deploy` and `app_prod_deploy` are [deploy](/platform/workflow/job/deploy) jobs that actually deploys the application manifest to their respective VM clusters.
 
-    Without adding any custom script, this deploy job will take any files in the manifest, and copy them to the nodes in the cluster.  It doesn't take any specific action with the files, it simply downloads them to a particular location on the hosts.  Since we want this deployment to actually update our running application, we'll have to add some commands to the job.
+    Without adding any custom script, this deploy job will take any files in the manifest, and copy them to the nodes in the cluster.  It doesn't take any specific action with the files; it simply downloads them to a particular location on the hosts.  Since we want this deployment to actually update our running application, we'll have to add some commands to the job.
 
     Unlike deployments to our supported container services, deployments to VM clusters allow for custom scripting.  This is because anything written in the `TASK` section of the job is executed *on the individual machines*, not on the Shippable platform.  So, if your VM cluster has two machines, the Shippable deployment service will ssh into each machine, one at a time, download the files from the manifest, and run the series of script commands in the `TASK` section.
 
@@ -205,7 +205,7 @@ Also, our application is written in nodejs and we're using foreverjs to run the 
 
 ###6. Import configuration into your Shippable account.
 
-Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [Sync repository](/platform/tutorial/workflow/crud-syncrepo/).
+Once you have these jobs and resources yml files as described above, commit them to your repository. This repository is called a [sync repository](/platform/tutorial/workflow/crud-syncrepo/).
 
 Follow [these instructions](/platform/tutorial/workflow/crud-syncrepo/) to import your configuration files into your Shippable account.
 

--- a/sources/getting-started/support.md
+++ b/sources/getting-started/support.md
@@ -59,7 +59,7 @@ Once a project is enabled, we build all commits and pull requests for that proje
 ## What is the difference between a Build Container (cexec) and Shippable Agent (genExec) on the Shippable platform?
 A Build Container (also called cexec) is a Docker Container that is spun up on the host Node machine that executes the Continuous Integration related tasks. These include installing the required dependencies, cloning information from the source control system repository, executing unit tests and running test/code coverage reports, all of which have to be specified in the `shippable.yml` file.  
 
-Shippable Agent (genExec) on the other hand is also a Docker Container that is spun up on the host Node machine. The main function of the Shippable Agent is to interact with the Shippable platform and the Build Container and, performs actions outside the build container. Within the `shippable.yml` file, the `pre_ci`, `pre_ci_boot` and the `push` sections are executed on the Shippable Agent. Pipeline related enhancements and runSH jobs are also executed on the Shippable Agent.
+Shippable Agent (genExec) on the other hand is also a Docker Container that is spun up on the host Node machine. The main function of the Shippable Agent is to interact with the Shippable platform and the Build Container and, performs actions outside the build container. Within the `shippable.yml` file, the `pre_ci`, `pre_ci_boot` and the `push` sections are executed on the Shippable Agent. Pipeline related enhancements and runSh jobs are also executed on the Shippable Agent.
 
 ---
 ## Why can't I see some of my repositories in my Shippable account?

--- a/sources/platform/tutorial/server/install-three-server-existing-db.md
+++ b/sources/platform/tutorial/server/install-three-server-existing-db.md
@@ -510,7 +510,7 @@ To enable caching, navigate to the `Build configuration` section in the `Configu
 ###9. Setup System or BYON node.
 * After step 7, login to Shippable Server as super user account.
 * If you choose the default option of `Enable system nodes` and `Enabled custom nodes`, you will need to
-setup the system or custom nodes to run your builds as well as runSh, and runCLI jobs.
+setup the system or custom nodes to run your CI and runSh jobs.
 * System nodes are system wide and can be used by any subscription for CI jobs. Custom nodes are added for a particular subscription and can only be used for builds in that subscription.
 * To setup Custom nodes, go [here](http://docs.shippable.com/getting-started/byon-manage-node/).
 * To setup System nodes, click on Admin -> Nodes -> System and click on '+' button. Follow the instructions

--- a/sources/platform/tutorial/server/install-three-server.md
+++ b/sources/platform/tutorial/server/install-three-server.md
@@ -287,7 +287,7 @@ To enable caching, navigate to the `Build configuration` section in the `Configu
 ###9. Setup System or BYON node.
 * After step 7, login to Shippable Server as super user account.
 * If you choose the default option of `Enable system nodes` and `Enabled custom nodes`, you will need to
-setup the system or custom nodes to run your builds as well as runSh, and runCLI jobs.
+setup the system or custom nodes to run your CI and runSh jobs.
 * System nodes are system wide and can be used by any subscription for CI jobs. Custom nodes are added for a particular subscription and can only be used for builds in that subscription.
 * To setup Custom nodes, go [here](http://docs.shippable.com/getting-started/byon-manage-node/).
 * To setup System nodes, click on Admin -> Nodes -> System and click on '+' button. Follow the instructions

--- a/sources/platform/tutorial/server/install-two-server.md
+++ b/sources/platform/tutorial/server/install-two-server.md
@@ -282,7 +282,7 @@ To enable caching, navigate to the `Build configuration` section in the `Configu
 ###8. Setup System or BYON node.
 * After step 7, login to Shippable Server as super user account.
 * If you choose the default option of `Enable system nodes` and `Enabled custom nodes`, you will need to
-setup the system or custom nodes to run your builds as well as runSh, and runCLI jobs.
+setup the system or custom nodes to run your CI and runSh jobs.
 * System nodes are system wide and can be used by any subscription for CI jobs. Custom nodes are added for a particular subscription and can only be used for builds in that subscription.
 * To setup Custom nodes, go [here](http://docs.shippable.com/getting-started/byon-manage-node/).
 * To setup System nodes, click on Admin -> Nodes -> System and click on '+' button. Follow the instructions

--- a/sources/platform/tutorial/workflow/sending-status-to-scm.md
+++ b/sources/platform/tutorial/workflow/sending-status-to-scm.md
@@ -8,19 +8,19 @@ page_keywords: Deploy multi containers, microservices, Continuous Integration, C
 
 ## Status notifications for Pull Requests
 
-If you have a [`gitRepo`](/platform/workflow/resource/gitrepo/) as IN to your `runCLI` job, you can see the job status for Pull Requests to your git repository .
+If you have a [`gitRepo`](/platform/workflow/resource/gitrepo/) as IN to your `runSh` job, you can see the job status for pull requests to your git repository .
 
 You can turn this ON or OFF using the `showBuildStatus` tag in the `gitRepo` resource.
 
-For example, the runCLI job will be configured in `shippable.jobs.yml` as shown below for this scenario:
+For example, the runSh job will be configured in `shippable.jobs.yml` as shown below for this scenario:
 
 ```
 jobs:
   - name: <name>                                
-    type: runCLI                               
+    type: runSh                             
     steps:                                      
       - IN: myGitRepo                           
-        showBuildStatus: true                   #set to true if you want job status to be shown in your SCM UI
+        showBuildStatus: true    #set to true if you want job status to be shown in your SCM UI
       - TASK:
         - script: <command>
         - script: <command>
@@ -37,19 +37,19 @@ resources:
     pointer:
       sourceName: <repoName>                    
       branch: <branchName>                      
-      buildOnPullRequest: true              #specify true to trigger the job for pull requests to the git repository
+      buildOnPullRequest: true     #specify true to trigger the job for pull requests to the git repository
 
 ```
 
-* If the **runCLI** job is triggered as a result of the a Pull Request for the configured repo (`repoName`) and (`branchName`), the build status message be displayed in the UI of your source control provider.
+* If the **runSh** job is triggered as a result of the a pull request for the configured repo (`repoName`) and (`branchName`), the build status message be displayed in the UI of your source control provider.
 
-* When the **runCLI** job is in the processing state the GitHub UI will look like
+* When the **runSh** job is in the processing state the GitHub UI will look like
 <img src="/images/platform/jobs/runCLI/processingBuildStatus.png" alt="Build Status Processing" style="width:800px;vertical-align: middle;display: block;margin-right: auto;"/>
 
-* When the **runCLI** job successfully completes, the GitHub UI will look like
+* When the **runSh** job successfully completes, the GitHub UI will look like
 <img src="/images/platform/jobs/runCLI/successBuildStatus.png" alt="Build Status Success" style="width:800px;vertical-align: middle;display: block;margin-right: auto;"/>
 
-* When the **runCLI** job is cancelled or failed the GitHub UI will look like
+* When the **runSh** job is cancelled or failed the GitHub UI will look like
 <img src="/images/platform/jobs/runCLI/failedBuildStatus.png" alt="Build Status Failed" style="width:800px;vertical-align: middle;display: block;margin-right: auto;"/>
 
 

--- a/sources/platform/visibility/single-pane-of-glass-spog.md
+++ b/sources/platform/visibility/single-pane-of-glass-spog.md
@@ -58,7 +58,7 @@ On clicking the build button, you get few options which allow you to make small 
 
 <img src="/images/getting-started/manual-build-config.png" alt="Build Config">
 
-For runSH and runCI jobs, you can provide custom environment variables.
+For runSh and runCI jobs, you can provide custom environment variables.
 
 <img src="/images/getting-started/manual-build-env.png" alt="Custom ENV">
 

--- a/sources/platform/workflow/job/release.md
+++ b/sources/platform/workflow/job/release.md
@@ -28,53 +28,48 @@ You can create a `release` job by [adding](/platform/tutorial/workflow/crud-job#
 
 ```
 jobs:
-  - name: 				<string>					#required
-    type: 				release		  				#required
-    on_start:										# optional
-      - NOTIFY: 		<notification resource name>
+  - name:               <string>                    # required
+    type:               release                     # required
+    bump:               <bump strategies>           # optional, defaults to minor
+    on_start:                                       # optional
+      - NOTIFY:         <notification resource name>
     steps:
-      - IN: 			<version>					# optional
-      - IN: 			<manifest/release/deploy> 	# optional
-      - IN: 			<manifest/release> 			# optional
-      - IN: 			<any job or resource>  		# optional
-      - TASK: 			managed
-        bump:			<bump strategies> 			# optional, defaults to minor
-    on_success:									# optional
-      - NOTIFY: 		<notification resource name>
-    on_failure:									# optional
-      - NOTIFY: 		<notification resource name>
-    on_cancel:										# optional
-      - NOTIFY: 		<notification resource name>
-    always:										# optional
-      - NOTIFY:		<notification resource name>
+      - IN:             <version>                   # optional
+      - IN:             <manifest/release/deploy>   # optional
+      - IN:             <manifest/release>          # optional
+      - IN:             <any job or resource>       # optional
+    on_success:                                     # optional
+      - NOTIFY:         <notification resource name>
+    on_failure:                                     # optional
+      - NOTIFY:         <notification resource name>
+    on_cancel:                                      # optional
+      - NOTIFY:         <notification resource name>
+    always:                                         # optional
+      - NOTIFY:         <notification resource name>
 ```
 
 * **`name`** -- should be an easy to remember text string
 
 * **`type`** -- is set to `manifest`
 
-* **`steps `** -- is an object which contains specific instructions to run this Job
+* **`bump`** -- This is used to control the strategy used to bump your seed version. Subsequent executions of this job will increment the last bumped value if it is semantically greater than the `seed`. If you want to reset, then just change the seed and it will start from the new seed again. Below is a list of accepted strategies and how they behave if a seed version of `v1.0.0` was used.
+    * `major` -- increments the major bit. So, first pass it will be `v2.0.0` and next one will be `v3.0.0`.
+    * `minor` -- increments the minor bit. So, first pass it will be `v1.1.0` and next one will be `v1.2.0`.
+    * `patch` -- increments the patch bit. So, first pass it will be `v1.0.1` and next one will be `v1.0.2`.
+    * `alpha` -- increments the alpha bit. So, first pass it will be `v1.0.0-alpha` and next one will be `v1.0.0-alpha.1`.
+    * `beta` -- increments the beta bit. So, first pass it will be `v1.0.0-beta` and next one will be `v1.0.0-beta.1`.
+    * `rc` -- increments the alpha bit. So, first pass it will be `v1.0.0-rc` and next one will be `v1.0.0-rc.1`.
+    * `final` -- removes pre-release flags on your incoming version, so if your input was `v4.0.0-rc.5`, then output version would be `v4.0.0`.
+
+* **`steps `** -- is an object which contains specific instructions to run this job
     * `IN` -- You need at least one source of a semVer string, and one `manifest`-based input (`manifest`, `release`, or `deploy`).  If you use multiple of them, then they will be deployed as a whole. Below is the list of all Resources and Jobs that can be supplied as `IN`
         * [version](/platform/workflow/resource/version/) -- This is used as the seed version that you want to start from. You can also use this to reset the current version back to a specific value.  This `IN` is optional if the job already has another source of a base version (such as a previous `release` job).
 
-        * [manifest](/platform/workflow/job/manifest)/[release](/platform/workflow/job/release)/[deploy](/platform/workflow/job/deploy) -- You can add zero or more of these.
-
-        * [release](/platform/workflow/job/release) -- You can add zero or more of these. `release` jobs can be `IN`s to other release jobs.  When you do this, the version produced from the incoming release job will be used as the base for the `bump` action instead of the `IN` version resource.
+        * [manifest](/platform/workflow/job/manifest)/[release](/platform/workflow/job/release)/[deploy](/platform/workflow/job/deploy) -- You can add zero or more of these. When you add a release job, the version produced from the incoming release job will be used as the base for the `bump` action instead of the `IN` version resource.
 
         * [deploy](/platform/workflow/job/deploy) -- You can add zero or more of these. Since a `deploy` job's output is a list of manifests, using it as an `IN` to a release job will result in that list of manifests being tagged with the version produced by the `release` job.
 
-        * Any other Job or Resource will only participate in triggering `release` job but not in of the processing of it.
-
-    * `TASK` -- Optional, but needs to be set to value `managed` if used
-        * `bump` -- This is used to control the strategy used to bump your seed version. Subsequent executions of this Job will increment the last bumped value if it is semantically greater than the `seed`. If you want to reset, then just change the seed and it will start from the new seed again. Below is a list of accepted strategies and how they behave if a seed version of `v1.0.0` was used.
-            * `major` -- increments the major bit. So, first pass it will be `v2.0.0` and next one will be `v3.0.0`.
-            * `minor` -- increments the minor bit. So, first pass it will be `v1.1.0` and next one will be `v1.2.0`.
-            * `patch` -- increments the patch bit. So, first pass it will be `v1.0.1` and next one will be `v1.0.2`.
-            * `alpha` -- increments the alpha bit. So, first pass it will be `v1.0.0-alpha` and next one will be `v1.0.0-alpha.1`.
-            * `beta` -- increments the beta bit. So, first pass it will be `v1.0.0-beta` and next one will be `v1.0.0-beta.1`.
-            * `rc` -- increments the alpha bit. So, first pass it will be `v1.0.0-rc` and next one will be `v1.0.0-rc.1`.
-            * `final` -- removes pre-release flags on your incoming version, so if your input was `v4.0.0-rc.5`, then output version would be `v4.0.0`.
-
+        * Any other job or resource will only participate in triggering `release` job but not in of the processing of it.
 
 * **`on_start`**, **`on_success`**, **`on_failure`**, **`on_cancel`**, **`always`** are used to send notifications for those events. You need to provide a [**notification**](/platform/workflow/resource/notification) resource pointing to the provider like Slack, Email, IRC, Hipchat, etc.
 

--- a/sources/platform/workflow/job/runcli.md
+++ b/sources/platform/workflow/job/runcli.md
@@ -8,7 +8,7 @@ page_keywords: Deploy multi containers, microservices, Continuous Integration, C
 
 # runCLI
 
-The runCLI job is deprecated. The complete functionality that was available in the runCLI job has been made available in the [runSH](/platform/workflow/job/runsh/#runsh) job. Our recommendation is to only use the [runSH](/platform/workflow/job/runsh/#runsh) job going forward. Your existing runCLI jobs will continue to run since we are passionate about not breaking any of our customers. We strongly encourage you regardless at the bare minimum, to rename the `type` attribute in your runCLI job yml to runSH. All your existing functionality will work as is and no further change is required to the yml block.
+The runCLI job is deprecated. The complete functionality that was available in the runCLI job has been made available in the [runSh](/platform/workflow/job/runsh/#runsh) job. Our recommendation is to only use the [runSh](/platform/workflow/job/runsh/#runsh) job going forward. Your existing runCLI jobs will continue to run since we are passionate about not breaking any of our customers. We strongly encourage you regardless at the bare minimum, to rename the `type` attribute in your runCLI job yml to runSh. All your existing functionality will work as is and no further change is required to the yml block.
 
 However, [Shippable Server](http://docs.shippable.com/platform/tutorial/server/install/) customers who are running older versions of Server (versions 5.7.3 and below) will still need to use the runCLI job. The documentation below should only be used by them.
 

--- a/sources/platform/workflow/job/runsh.md
+++ b/sources/platform/workflow/job/runsh.md
@@ -1,4 +1,4 @@
-page_main_title: runSH
+page_main_title: runSh
 main_section: Platform
 sub_section: Workflow
 sub_sub_section: Jobs
@@ -7,13 +7,13 @@ page_description: List of supported jobs
 page_keywords: Deploy multi containers, microservices, Continuous Integration, Continuous Deployment, CI/CD, testing, automation, pipelines, docker, lxc
 
 # runSh
-`runSh` is a Job that lets you run any `shell` script as part of your DevOps Assembly Line. It is one of the most versatile Jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted. With a combination of `IN`s like `params`, `integration`, `gitRepo` etc. the vision of "Everything as Code" can be realized.
+`runSh` is a job that lets you run any `shell` script as part of your DevOps Assembly Line. It is one of the most versatile Jobs in the arsenal and can be used to pretty much execute any DevOps activity that can be scripted. With a combination of `IN`s like `params`, `integration`, `gitRepo`, etc., the vision of "Everything as Code" can be realized.
 
-You should use this job type if you need the freedom that some of the pre-packaged Jobs like [deploy](/platform/workflow/job/deploy) and [manifest](/platform/workflow/job/manifest) do not provide, or if they do not support the 3rd party end-point you want to integrate to. For example, pushing to Heroku is not yet natively supported through a managed job type, so you can write the scripts needed to do this and add it to your workflow as a job of type `runSh`.
+You should use this job type if you need the freedom that some of the pre-packaged jobs like [deploy](/platform/workflow/job/deploy) and [manifest](/platform/workflow/job/manifest) do not provide, or if they do not support the 3rd party end-point you want to integrate with. For example, pushing to Heroku is not yet natively supported through a managed job type, so you can write the scripts needed to do this and add it to your workflow as a job of type `runSh`.
 
 You can also add [cliConfig](/platform/workflow/resource/cliconfig) resources as inputs to this job. The relevant CLI tools will be preconfigured for your scripts to use. For a complete list of supported cliConfig integrations see [here](/platform/workflow/resource/cliconfig#cliConfigTools).
 
-A new version is created anytime this Job is executed.
+A new version is created anytime this job is executed.
 
 You can create a `runSh` Job by [adding](/platform/tutorial/workflow/crud-job#adding) it to `shippable.jobs.yml` and it executes on Shippable provided [Dynamic Nodes](/platform/runtime/overview#nodes) or [Custom Nodes](/platform/runtime/overview#nodes)
 
@@ -79,7 +79,7 @@ A full detailed description of each tag is available on the [Job Anatomy](/platf
 * **`always `** -- Optional, and both `script` and `NOTIFY` types can be used
 
 ## cliConfig special handling
-If a Resource of type [cliConfig](/platform/workflow/resource/cliconfig) based Resource is added an `IN` into `runSh`, then the corresponding CLI is automatically configured and prepared for you to execute CLI specific commands. The runCLI job uses the subscription integration specified in `cliConfig` to determine which CLI tools to configure. For e.g. if you use a `cliConfig` that uses Docker based integration, then we will automatically log you into the hub based on the configuration. This removes the need for you to having to do this manually.
+If a resource of type [cliConfig](/platform/workflow/resource/cliconfig) is added an `IN` into `runSh`, then the corresponding CLI is automatically configured and prepared for you to execute CLI specific commands. The job uses the subscription integration specified in `cliConfig` to determine which CLI tools to configure. E.g., if you use a `cliConfig` that uses Docker based integration, then we will automatically log you into the hub based on the configuration. This removes the need for you to having to do this manually.
 
 Here is a list of the tools configured for each integration type:
 

--- a/sources/platform/workflow/resource/cliconfig.md
+++ b/sources/platform/workflow/resource/cliconfig.md
@@ -48,7 +48,7 @@ resources:
 <a name="cliConfigTools"></a>
 ## Configured CLI tools
 
-The runCLI and runSh job uses the subscription integration specified in the
+A runSh job uses the subscription integration specified in the
 cliConfig to determine which CLI tools to configure.
 These tools are configured with the credentials contained in the subscription
 integration. Here is a list of the tools configured for each integration type:

--- a/sources/provision/aws-with-ansible.md
+++ b/sources/provision/aws-with-ansible.md
@@ -4,8 +4,7 @@ sub_section: Provisioning with Ansible
 
 # AWS with Ansible
 With Shippable, you can use Ansible from Red Hat within Pipelines to provision
-infrastructure on AWS. You would do so with a `runCLI` or
-`runSh` job.
+infrastructure on AWS. You would do so with a `runSh` job.
 
 ##Setup
 
@@ -21,9 +20,8 @@ Integration**
 -  Locate **AWS** in the list and click on **Create Integration**
 -  Name your integration and enter your AWS Access Key ID and AWS Secret Access
 Key for an IAM User with the appropriate policies set to perform the provisioning
-actions you will execute (e.g. create/delete EC/2 instances)
--  Choose the Subscription(s) that are allowed to use these credentials.
-push the image
+actions you will execute (e.g. create/delete EC2 instances)
+-  Choose the subscription(s) that are allowed to use these credentials.
 -  Click **Save**
 
 <img src="../../images/provision/amazon-web-services-integration.png" alt="add
@@ -39,9 +37,9 @@ resources and jobs:
     *  **gitRepo** - contains your Ansible scripts
     *  **integration** - to store you ssh key for use by ansible
 -  jobs
-    *  **runCLI** - for executing your Ansible scripts
+    *  **runSh** - for executing your Ansible scripts
 
-in `shippable.resources.yml`, define the following resources to be used as
+In `shippable.resources.yml`, define the following resources to be used as
 inputs to your pipeline:
 
 ```yaml
@@ -66,13 +64,13 @@ inputs to your pipeline:
     integration: mysshintegration # replace with your ssh/pem integration name
 ```
 
-in `shippable.jobs.yml`, define the following job in order to execute Ansible
-an Ansible playbook to provision on aws from your pipeline:
+In `shippable.jobs.yml`, define the following job in order to execute
+an Ansible playbook to provision on AWS from your pipeline:
 
 ```yaml
 # job to execute Ansible script to provision aws instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myAwsCliConfig
@@ -105,7 +103,7 @@ Using Ansible with AWS, you'll likely want to separate your 'provision' actions
 from your 'terminate' actions. In this manner you can easily trigger either
 action on-demand or via automated triggers.
 
-To set up this Pipeline, simply separate your provision and terminate actions
+To set up this pipeline, simply separate your provision and terminate actions
 into separate jobs and name the 'provision' job as an input to the
 'terminate' job.
 
@@ -113,7 +111,7 @@ into separate jobs and name the 'provision' job as an input to the
 ```yaml
 # job to execute Ansible script to provision aws instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myAwsCliConfig
@@ -142,7 +140,7 @@ into separate jobs and name the 'provision' job as an input to the
 
 # job to execute Ansible script to terminate aws instances
   - name: myTerminateJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myProvisionJob     
       - IN: myGithubRepo
@@ -172,7 +170,7 @@ into separate jobs and name the 'provision' job as an input to the
 ```
 
 ### Create timed Ansible pipeline job
-To schedule a Pipeline job to automatically execute an Ansible playbook on a
+To schedule a pipeline job to automatically execute an Ansible playbook on a
 recurring basis, add a `time` resource.
 
 `shippable.resources.yml`:
@@ -188,7 +186,7 @@ recurring basis, add a `time` resource.
 ```yaml
 # job to execute Ansible script to provision aws instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
 ```

--- a/sources/provision/aws-with-terraform.md
+++ b/sources/provision/aws-with-terraform.md
@@ -3,8 +3,8 @@ main_section: Provision
 sub_section: Provisioning with Terraform
 
 # AWS with Terraform
-With Shippable, you can use Terraform from Hashicorp within Pipelines to
-provision infrastructure on AWS. You would do so with a `runCLI` or `runSh` job.
+With Shippable, you can use Terraform from Hashicorp within Shippable Assembly Lines to
+provision infrastructure on AWS. You would do so with a `runSh` job.
 
 ##Setup
 
@@ -20,9 +20,8 @@ Integration**
 -  Locate **AWS** in the list and click on **Create Integration**
 -  Name your integration and enter your AWS Access Key ID and AWS Secret Access
 Key for an IAM User with the appropriate policies set to perform the provisioning
-actions you will execute (e.g. create/delete EC/2 instances)
--  Choose the Subscription(s) that are allowed to use these credentials.
-push the image
+actions you will execute (e.g. create/delete EC2 instances)
+-  Choose the subscription(s) that are allowed to use these credentials.
 -  Click **Save**
 
 <img src="../../images/provision/amazon-web-services-integration.png" alt="add
@@ -37,9 +36,9 @@ resources and jobs:
     *  **cliConfig** - to configure the default AWS CLI settings
     *  **gitRepo** - contains your Terraform scripts
 -  jobs
-    *  **runCLI** - for executing your Terraform scripts
+    *  **runSh** - for executing your Terraform scripts
 
-in `shippable.resources.yml`, define the following resources to be used as
+In `shippable.resources.yml`, define the following resources to be used as
 inputs to your pipeline:
 
 ```yaml
@@ -59,13 +58,13 @@ inputs to your pipeline:
       branch: master
 ```
 
-in `shippable.jobs.yml`, define the following job in order to execute Terraform
+In `shippable.jobs.yml`, define the following job in order to execute Terraform
 scripts to provision on AWS from your pipeline:
 
 ```yaml
 # job to execute Terraform script to provision AWS instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myAwsCliConfig
@@ -96,8 +95,8 @@ scripts to provision on AWS from your pipeline:
           cp terraform.tfstate /build/state
 ```
 
-NOTE: The Terraform CLI is pre-installed on Shippable's standard runCLI job
-runtime images. You do not need to do so as part of your runCLI job.
+NOTE: The Terraform CLI is pre-installed on Shippable's standard runSh job
+runtime images. You do not need to do so as part of your runSh job.
 
 
 ## Advanced config
@@ -106,7 +105,7 @@ Using Terraform with AWS, you'll likely want to separate your 'provision' action
 from your 'terminate' actions. In this manner you can easily trigger either
 action on-demand or via automated triggers.
 
-To set up this Pipeline, simply separate your provision and terminate actions
+To set up this pipeline, simply separate your provision and terminate actions
 into separate jobs and name the 'provision' job as an input to the
 'terminate' job.
 
@@ -114,7 +113,7 @@ into separate jobs and name the 'provision' job as an input to the
 ```yaml
 # job to execute Terraform script to provision AWS instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myAwsCliConfig
@@ -146,7 +145,7 @@ into separate jobs and name the 'provision' job as an input to the
 
 # job to execute Terraform script to terminate AWS instances
   - name: myTerminateJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myProvisionJob     
       - IN: myGithubRepo
@@ -180,7 +179,7 @@ into separate jobs and name the 'provision' job as an input to the
 ```
 
 ### Create timed Terraform pipeline job
-To schedule a Pipeline job to automatically execute a Terraform script on a
+To schedule a pipeline job to automatically execute a Terraform script on a
 recurring basis, add a `time` resource.
 
 `shippable.resources.yml`:
@@ -196,7 +195,7 @@ recurring basis, add a `time` resource.
 ```yaml
 # job to execute Terraform script to provision AWS instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myNightlyTrigger
 ```

--- a/sources/provision/digital-ocean-with-ansible.md
+++ b/sources/provision/digital-ocean-with-ansible.md
@@ -4,7 +4,7 @@ sub_section: Provisioning with Ansible
 
 # Digital Ocean with Ansible
 With Shippable, you can use [Ansible](https://www.ansible.com/) from Red Hat within Pipelines to provision
-infrastructure on [Digital Ocean](https://www.digitalocean.com/). You would do so with a `runCLI` or
+infrastructure on [Digital Ocean](https://www.digitalocean.com/). You would do so with a
 `runSh` job. Both of those jobs have ansible command line tools and [digital ocean module](http://docs.ansible.com/ansible/list_of_cloud_modules.html#digital-ocean) requirements (python >= 2.6 and dopy) installed already.
 
 ##Setup
@@ -33,9 +33,9 @@ resources and jobs:
     *  **cliConfig** - to configure the default digital ocean cli settings
     *  **gitRepo** - contains your Ansible scripts
 -  jobs
-    *  **runCLI** - for executing your Ansible scripts
+    *  **runSh** - for executing your Ansible scripts
 
-in `shippable.resources.yml`, define the following resources to be used as
+In `shippable.resources.yml`, define the following resources to be used as
 inputs to your pipeline:
 
 ```yaml
@@ -53,13 +53,13 @@ inputs to your pipeline:
       branch: master
 ```
 
-in `shippable.jobs.yml`, define the following job in order to execute Ansible
+in `shippable.jobs.yml`, define the following job in order to execute
 an Ansible playbook to provision on digital ocean from your pipeline:
 
 ```yaml
 # job to execute Ansible script to provision droplets
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myDOCliConfig
@@ -70,7 +70,7 @@ an Ansible playbook to provision on digital ocean from your pipeline:
             ansible-playbook -v digital-ocean-provision.yml
 ```
 
-`myGithubRepo` git repository should contain `digital-ocean-provision.yml` which should be a valid ansible playbook having a provisioning task for digital ocean. Example of `digital-ocean-provision.yml` might be
+`myGithubRepo` git repository should contain `digital-ocean-provision.yml` which should be a valid Ansible playbook with a provisioning task for Digital Ocean. Example of `digital-ocean-provision.yml` might be
 
 ```yaml
 - name: Digital Ocean Cloud Provision
@@ -87,10 +87,10 @@ an Ansible playbook to provision on digital ocean from your pipeline:
         image_id: "ubuntu-16-04-x64"
 ```
 
-In our `runCLI` job, `IN: myDOCliConfig` gives an environment variable named `MYDOCLICONFIG_INTEGRATION_APITOKEN` that will be having the API token specified in the Digital Ocean integration. Note that, the environment variable name is generated based on the format `x_INTEGRATION_APITOKEN`, where x is the cliConfig resource name in upper case.
+In our `runSh` job, `IN: myDOCliConfig` gives an environment variable named `MYDOCLICONFIG_INTEGRATION_APITOKEN` that will have the API token specified in the Digital Ocean integration. Note that, the environment variable name is generated based on the format `x_INTEGRATION_APITOKEN`, where x is the cliConfig resource name in upper case with any characters other than letters, numbers, or underscores removed.
 
 ### Create timed Ansible pipeline job
-To schedule a Pipeline job to automatically execute an Ansible playbook on a
+To schedule a pipeline job to automatically execute an Ansible playbook on a
 recurring basis, add a `time` resource.
 
 `shippable.resources.yml`:
@@ -106,7 +106,7 @@ recurring basis, add a `time` resource.
 ```yaml
 # job to execute Ansible script to provision droplet
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myNightlyTrigger
 ```

--- a/sources/provision/google-cloud-with-ansible.md
+++ b/sources/provision/google-cloud-with-ansible.md
@@ -4,7 +4,7 @@ sub_section: Provisioning with Ansible
 
 # Google Cloud with Ansible
 With Shippable, you can use [Ansible](https://www.ansible.com/) from Red Hat within Pipelines to provision
-infrastructure on [Google Cloud](https://cloud.google.com/). You would do so with a `runCLI` or
+infrastructure on [Google Cloud](https://cloud.google.com/). You would do so with a
 `runSh` job. Both of those jobs have ansible command line tools and [google module](http://docs.ansible.com/ansible/list_of_cloud_modules.html#google) requirements (python >= 2.6 and apache-libcloud) installed already.
 
 ##Setup
@@ -33,9 +33,9 @@ resources and jobs:
     *  **cliConfig** - to configure the default google cloud cli settings
     *  **gitRepo** - contains your Ansible scripts
 -  jobs
-    *  **runCLI** - for executing your Ansible scripts
+    *  **runSh** - for executing your Ansible scripts
 
-in `shippable.resources.yml`, define the following resources to be used as
+In `shippable.resources.yml`, define the following resources to be used as
 inputs to your pipeline:
 
 ```yaml
@@ -53,13 +53,13 @@ inputs to your pipeline:
       branch: master
 ```
 
-in `shippable.jobs.yml`, define the following job in order to execute Ansible
-an Ansible playbook to provision on google cloud from your pipeline:
+In `shippable.jobs.yml`, define the following job in order to execute
+an Ansible playbook to provision on Google Cloud from your pipeline:
 
 ```yaml
 # job to execute Ansible script to provision aws instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myGclCliConfig
@@ -70,7 +70,7 @@ an Ansible playbook to provision on google cloud from your pipeline:
             ansible-playbook -v google-cloud-provision.yml
 ```
 
-`myGithubRepo` git repository should contain `google-cloud-provision.yml` which should be a valid ansible playbook having a provisioning task for google cloud. Example of `google-cloud-provision.yml` might be
+`myGithubRepo` git repository should contain `google-cloud-provision.yml` which should be a valid ansible playbook with a provisioning task for Google Cloud. Example of `google-cloud-provision.yml` might be
 
 ```yaml
 
@@ -89,15 +89,16 @@ an Ansible playbook to provision on google cloud from your pipeline:
         project_id: "{{ ansible_env.MYGCLCLICONFIG_INTEGRATION_PROJECTNAME }}"
 ```
 
-In our `runCLI` job, `IN: myGclCliConfig` gives the following environment variables
-- `MYGCLCLICONFIG_INTEGRATION_PROJECTNAME` - Project name given in the google cloud account integration.
-- `MYGCLCLICONFIG_INTEGRATION_SERVICEACCOUNTEMAIL` - Service Account Email given in the google cloud account integration.
-- `MYGCLCLICONFIG_INTEGRATION_CREDENTIALFILE_PATH` - Path of the credential file with the content given in the google cloud account integration.
+In our `runSh` job, `IN: myGclCliConfig` gives the following environment variables:
 
-Note that, the environment variable name is generated based on the format `x_INTEGRATION_APITOKEN`, where x is the cliConfig resource name in upper case.
+  - `MYGCLCLICONFIG_INTEGRATION_PROJECTNAME` - Project name given in the Google Cloud account integration.
+  - `MYGCLCLICONFIG_INTEGRATION_SERVICEACCOUNTEMAIL` - Service Account Email given in the Google Cloud account integration.
+  - `MYGCLCLICONFIG_INTEGRATION_CREDENTIALFILE_PATH` - Path of the credential file with the content given in the Google Cloud account integration.
+
+Note that, the environment variable name is generated based on the format `x_INTEGRATION_APITOKEN`, where x is the cliConfig resource name in upper case with any characters other than letters, numbers, or underscores removed.
 
 ### Create timed Ansible pipeline job
-To schedule a Pipeline job to automatically execute an Ansible playbook on a
+To schedule a pipeline job to automatically execute an Ansible playbook on a
 recurring basis, add a `time` resource.
 
 `shippable.resources.yml`:
@@ -113,7 +114,7 @@ recurring basis, add a `time` resource.
 ```yaml
 # job to execute Ansible script to provision google cloud instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myNightlyTrigger
 ```

--- a/sources/provision/microsoft-azure-with-ansible.md
+++ b/sources/provision/microsoft-azure-with-ansible.md
@@ -4,7 +4,7 @@ sub_section: Provisioning with Ansible
 
 # Microsoft Azure with Ansible
 With Shippable, you can use [Ansible](https://www.ansible.com/) from Red Hat within Pipelines to provision
-infrastructure on [Microsoft Azure](https://azure.microsoft.com/). You would do so with a `runCLI` or
+infrastructure on [Microsoft Azure](https://azure.microsoft.com/). You would do so with a
 `runSh` job. Both of those jobs have ansible command line tools and [azure module](http://docs.ansible.com/ansible/list_of_cloud_modules.html#azure) requirements (python >= 2.6 and azure) installed already.
 
 ##Setup
@@ -33,9 +33,9 @@ resources and jobs:
     *  **cliConfig** - to configure the default microsoft azure cli settings
     *  **gitRepo** - contains your Ansible scripts
 -  jobs
-    *  **runCLI** - for executing your Ansible scripts
+    *  **runSh** - for executing your Ansible scripts
 
-in `shippable.resources.yml`, define the following resources to be used as
+In `shippable.resources.yml`, define the following resources to be used as
 inputs to your pipeline:
 
 ```yaml
@@ -53,13 +53,13 @@ inputs to your pipeline:
       branch: master
 ```
 
-in `shippable.jobs.yml`, define the following job in order to execute Ansible
+In `shippable.jobs.yml`, define the following job in order to execute
 an Ansible playbook to provision on Microsoft Azure from your pipeline:
 
 ```yaml
 # job to execute Ansible script to provision Microsoft Azure instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myGithubRepo
       - IN: myMazCliConfig
@@ -70,7 +70,7 @@ an Ansible playbook to provision on Microsoft Azure from your pipeline:
             ansible-playbook -v microsoft-azure-provision.yml
 ```
 
-`myGithubRepo` git repository should contain `microsoft-azure-provision.yml` which should be a valid ansible playbook having a provisioning task for microsoft azure. Example of `microsoft-azure-provision.yml` might be
+`myGithubRepo` git repository should contain `microsoft-azure-provision.yml` which should be a valid ansible playbook with a provisioning task for Microsoft Azure. Example of `microsoft-azure-provision.yml` might be
 
 ```yaml
 
@@ -112,15 +112,16 @@ an Ansible playbook to provision on Microsoft Azure from your pipeline:
           version: latest
 ```
 
-In our `runCLI` job, `IN: myMazCliConfig` gives the following environment variables
-- `MYMAZCLICONFIG_INTEGRATION_USERNAME` - Username given in the microsoft azure account integration.
-- `MYMAZCLICONFIG_INTEGRATION_PASSWORD` - Password given in the microsoft azure account integration.
-- `MYMAZCLICONFIG_INTEGRATION_SUBSCRIPTIONID` - Subscription Id given in the microsoft azure account integration.
+In our `runSh` job, `IN: myMazCliConfig` gives the following environment variables
 
-Note that, the environment variable name is generated based on the format `x_INTEGRATION_APITOKEN`, where x is the cliConfig resource name in upper case.
+  - `MYMAZCLICONFIG_INTEGRATION_USERNAME` - Username given in the Microsoft Azure account integration.
+  - `MYMAZCLICONFIG_INTEGRATION_PASSWORD` - Password given in the Microsoft Azure account integration.
+  - `MYMAZCLICONFIG_INTEGRATION_SUBSCRIPTIONID` - Subscription Id given in the Microsoft Azure account integration.
+
+Note that, the environment variable name is generated based on the format `x_INTEGRATION_APITOKEN`, where x is the cliConfig resource name in upper case with any characters other than letters, numbers, or underscores removed.
 
 ### Create timed Ansible pipeline job
-To schedule a Pipeline job to automatically execute an Ansible playbook on a
+To schedule a pipeline job to automatically execute an Ansible playbook on a
 recurring basis, add a `time` resource.
 
 `shippable.resources.yml`:
@@ -136,7 +137,7 @@ recurring basis, add a `time` resource.
 ```yaml
 # job to execute Ansible script to provision microsoft azure instances
   - name: myProvisionJob
-    type: runCLI
+    type: runSh
     steps:
       - IN: myNightlyTrigger
 ```

--- a/sources/release/increment-version-number.md
+++ b/sources/release/increment-version-number.md
@@ -42,11 +42,10 @@ The `bump` directive in the release job specifies how the version number should 
   # Release job    
   - name: release-job
     type: release
+    bump: major
     steps:
       - IN: java-img-manifest
       - IN: release-version
-      - TASK: managed
-        bump: major
 ```
 
 - Running the release job will set the current version to 2.0.0 since `bump` was set to `major`.
@@ -60,11 +59,10 @@ The `bump` directive in the release job specifies how the version number should 
   # Release job    
   - name: release-job
     type: release
+    bump: minor
     steps:
       - IN: java-img-manifest
       - IN: release-version
-      - TASK: managed
-        bump: minor
 ```
 
 - Running the release job will set the current version to 1.1.0 since `bump` was set to `minor`.
@@ -78,11 +76,10 @@ The `bump` directive in the release job specifies how the version number should 
   # Release job    
   - name: release-job
     type: release
+    bump: patch
     steps:
       - IN: java-img-manifest
       - IN: release-version
-      - TASK: managed
-        bump: patch
 ```
 
 - Running the release job will set the current version to 1.0.1 since `bump` was set to `patch`.
@@ -96,11 +93,10 @@ The `bump` directive in the release job specifies how the version number should 
   # Release job    
   - name: release-job
     type: release
+    bump: alpha
     steps:
       - IN: java-img-manifest
       - IN: release-version
-      - TASK: managed
-        bump: alpha
 ```
 
 - Running the release job will set the current version to 1.0.0-alpha since `bump` was set to `alpha`. The next run will set the version to 1.0.0-alpha.1.
@@ -114,11 +110,10 @@ The `bump` directive in the release job specifies how the version number should 
   # Release job    
   - name: release-job
     type: release
+    bump: beta
     steps:
       - IN: java-img-manifest
       - IN: release-version
-      - TASK: managed
-        bump: beta
 ```
 
 - Running the release job will set the current version to 1.0.0-beta since `bump` was set to `beta`. The next run will set the version to 1.0.0-beta.1.
@@ -133,11 +128,10 @@ The `bump` directive in the release job specifies how the version number should 
   # Release job    
   - name: release-job
     type: release
+    bump: rc
     steps:
       - IN: java-img-manifest
       - IN: release-version
-      - TASK: managed
-        bump: rc
 ```
 
 - Running the release job will set the current version to 1.0.0-rc since `bump` was set to `rc`. The next run will set the version to 1.0.0-rc.1.

--- a/sources/release/single-component.md
+++ b/sources/release/single-component.md
@@ -45,11 +45,10 @@ jobs:
   # Release job
   - name: my-release
     type: release
+    bump: beta
     steps:
       - IN: my-version
       - IN: my-manifest
-      - TASK: managed
-        bump: beta
 ```
 
 * `name` should be an easy to remember text string. This will appear in the visualization of this job in the SPOG.

--- a/sources/release/upstream-releases.md
+++ b/sources/release/upstream-releases.md
@@ -60,12 +60,11 @@ images that we want to version before deployment to the Amazon ECS cluster.
   # Release job
   - name: release-from-upstream-release-upstream-release-job
     type: release
+    bump: beta
     steps:
       - IN: release-from-upstream-release-node-img-manifest-job
       - IN: release-from-upstream-release-java-img-manifest-job
       - IN: upstream-release-version
-      - TASK: managed
-        bump: beta
     flags:
       - release-from-upstream-release-jobs
 ```
@@ -88,10 +87,9 @@ This results in the version of the upstream release job being fed as input to it
 
     - name: release-from-upstream-release-downstream-release-job
       type: release
+      bump: rc
       steps:
         - IN: release-from-upstream-release-deploy-ecs-job
-        - TASK: managed
-          bump: rc
       flags:
         - release-from-upstream-release-jobs
 ```

--- a/sources/validate/nouvola.md
+++ b/sources/validate/nouvola.md
@@ -9,7 +9,7 @@ performance tests on your application using a third party tool.
 
 [**Nouvola**](http://www.nouvola.com/) is a popular third-party service that offers real-world performance & load testing for web, mobile, API and IoT apps so developers, DevOps and engineering managers can release better code faster
 
-You can automatically trigger your test suite authored in Nouvola, after your application has been deployed using Shippable. This tutorial demonstrates how to run Nouvola test plans using [runSH](/platform/workflow/job/runsh/) jobs on a service you have already deployed.
+You can automatically trigger your test suite authored in Nouvola, after your application has been deployed using Shippable. This tutorial demonstrates how to run Nouvola test plans using [runSh](/platform/workflow/job/runsh/) jobs on a service you have already deployed.
 
 ## Prerequisites
 
@@ -41,7 +41,7 @@ resources:
         secure: QbUdwdZzHSnFlKPxcsjJMp/qyICw4DPa2+VkqG9G42rYGCIAbecTVdIC933mljlJ1Z+OKhxk2zEevrczi7FxqLR+ts16AtvXHgRgwdmLLWmxX3trjfXDSWXOE5+GNHYmaZOQLm8qQjouogP8Kkx8njYj9Uut4ONaNZUsHvVroVSyfwiPktyKjQP8iEIzaV/Jb1wWwLHsDf1n4GaCcbm1VuloxoNuJkG5VftcnMqULWyN9YeZTxQ43PiflTWFqBHV9hPpbVU+N5Jt1kGfhBlj6FdiIiB69KrXXd/ooBwz7UuuNgPyXEjZtUC0tp0CzZlovnNPBdrMRiZ/yE1ZgbuDbQ==
 ```
 5. You can find the Plan ID in the test plan page, in parenthesis (xxx), next to the test Name in the Nouvola dashboard.
-6. We are going to call a script that executes Nouvola API calls in our runSH job. In order to do so, we need to also specify our repository as a resource in the shippable.resources.yml file.
+6. We are going to call a script that executes Nouvola API calls in our runSh job. In order to do so, we need to also specify our repository as a resource in the shippable.resources.yml file.
 
 ```
 # GitHub repo holding scripts to be used in runsh pipeline job
@@ -94,9 +94,9 @@ you will see something like this in your console -
 
 The build will complete when status transitions from Waiting->Starting->Working->Analyzing->Emailed.
 
-## Connecting the runSH job to your deploy job in the pipeline
+## Connecting the runSh job to your deploy job in the pipeline
 
-If you have created a pipeline with a deploy job and want to run these tests after your deploy job completes, there is a simple way to connect your runSH job to your deploy job. We will connect the deploy job specified in[ECS deploy](/deploy/cd_of_single_container_applications_to_orchestration_platforms/) using an OUT directive.
+If you have created a pipeline with a deploy job and want to run these tests after your deploy job completes, there is a simple way to connect your runSh job to your deploy job. We will connect the deploy job specified in[ECS deploy](/deploy/cd_of_single_container_applications_to_orchestration_platforms/) using an OUT directive.
 
 ```
   - name: deploy-ecs-basic-deploy


### PR DESCRIPTION
#608 

Updates `bump` to move it to the top level.  And replaces almost all of the remaining references to runCLI with runSh and fixes a few runSh mentions with the wrong capitalization.