### PR TITLE
mark email integration as deprecated

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -258,7 +258,6 @@ pages:
       - Docker Datacenter: platform/integration/docker-datacenter.md
       - Docker Hub: platform/integration/docker-hub.md
       - Docker Trusted Registry: platform/integration/docker-trusted-registry.md
-      - Email: platform/integration/email.md
       - Event Trigger: platform/integration/event-trigger.md
       - Git Credential: platform/integration/git-credential.md
       - GitHub: platform/integration/github.md
@@ -287,6 +286,7 @@ pages:
         - PEM Keys: platform/integration/key-pem.md
         - SSH Keys: platform/integration/key-ssh.md
         - Quay.io: platform/integration/quay.md
+        - Email: platform/integration/email.md
     - Runtime:
       - Overview: platform/runtime/overview.md
       - Operating System:

--- a/sources/platform/integration/email.md
+++ b/sources/platform/integration/email.md
@@ -3,7 +3,14 @@ main_section: Platform
 sub_section: Integrations
 page_title: EMail integration
 
-# Email Integration
+# Email Integration (Deprecated)
+
+## Deprecation Note
+This integration has been deprecated. You can get email notifications in [CI](/ci/email-notifications.md) and [assembly lines](platform/workflow/resource/notification/) by specifying recipients in yml files.
+
+If you have any existing Email integrations you _can_ continue to use them. New integrations of type Email _cannot_ be created anymore.
+
+---
 
 The **Email** Integration is used to connect Shippable DevOps Assembly Lines platform so that you can send notifications to an email address.
 


### PR DESCRIPTION
https://github.com/Shippable/docs/issues/632

moves `Email` integration under `Deprecated` list and adds deprecation note for email. 