### PR TITLE
add back the details on creating a kube service account

### DIFF
--- a/sources/platform/integration/kubernetes.md
+++ b/sources/platform/integration/kubernetes.md
@@ -23,6 +23,91 @@ Here is the information you need to create this integration:
 		* Nodes -- IP address of the Bastion Host
 		* KubeConfig File -- Configuration file to access Kubernetes cluster  
 
+## Creating a kubeconfig file
+
+The best way to create an isolated set of credentials for use with Shippable Assembly Lines is to create a Kubernetes Service Account, and set up a custom kubeconfig file that utilizes it.
+
+### Create the Service Account
+
+- Make sure you're on a machine that has a configured kubectl that can interact with your cluster
+- Create a `shippable-service-account.yaml` file to represent the service account
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: shippable-deploy #any name you'd like
+```
+- Use kubectl to create the service account on the master
+```
+$ kubectl create -f shippable-service-account.yaml
+serviceaccount "shippable-deploy" created
+```
+
+### Create the kubeconfig file
+
+First, we'll get the credentials for the service account that we created, then we'll add those credentials to a "context" within our kubeconfig file.
+
+- Use kubectl to describe the service account so you can see its details
+```
+$ kubectl describe serviceAccounts shippable-deploy
+Name:		shippable-deploy
+Namespace:	default
+Labels:		<none>
+Annotations:	<none>
+
+Image pull secrets:	<none>
+
+Mountable secrets: 	shippable-deploy-token-h6pdj
+
+Tokens:            	shippable-deploy-token-h6pdj
+```
+- Now describe the secret token associated with the account
+```
+$ kubectl describe secrets shippable-deploy-token-h6pdj
+Name:		shippable-deploy-token-h6pdj
+Namespace:	default
+Labels:		<none>
+Annotations:	kubernetes.io/service-account.name=shippable-deploy
+		kubernetes.io/service-account.uid=da401cc4-3430-11e7-8529-42010a800fc8
+
+Type:	kubernetes.io/service-account-token
+
+Data
+====
+ca.crt:		1119 bytes
+namespace:	7 bytes
+token:		eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3Nlcn...
+```
+- Next, copy the existing kubeconfig from kubectl to a file so that it can be modified
+```
+$ kubectl config view --flatten --minify > myConfig.config
+```
+- Update the kubeconfig file to utilize the serviceAccount token. It should look similar to this:
+```
+apiVersion: v1
+kind: Config
+users:
+- name: shippable-deploy
+  user:
+    token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3Nlcn...
+clusters:
+- name: my-kube-cluster
+  cluster:
+     server: https://us-central1.sample.com
+     certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREREND...
+contexts:
+- context:
+    cluster: my-kube-cluster
+    user: shippable-deploy
+  name: shippable-context
+current-context: shippable-context
+```
+- Make sure the `user` is the name of the serviceAccount, and check that it is updated in the `users` section as well as the `context` section.
+- Check that the `current-context` states the name of the context that references the correct cluster and the correct serviceAccount user.
+- This assumes that the kubeconfig you started with already had the server and certificate authority information in the cluster section.
+- Finally, take this kubeconfig file that you created, and use it to create your Shippable Kubernetes Integration.
+
 ## Usage in Assembly Lines
 
 The Kubernetes integration can be used in the following [resources](/platform/workflow/resource/overview/):


### PR DESCRIPTION
This workflow got left out when we transtiioned to new docs format, however I think the information is very useful and relevant, and should be kept on the kubernetes integration page.