### PR TITLE
#644; notes that IRC integrations are deprecated.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -267,7 +267,6 @@ pages:
       - Google Container Engine: platform/integration/gke.md
       - Google Container Registry: platform/integration/gcr.md
       - HipChat: platform/integration/hipchat.md
-      - IRC: platform/integration/irc.md
       - Jenkins: platform/integration/jenkins.md
       - JFrog Artifactory: platform/integration/jfrog-artifactoryKey.md
       - Joyent Triton: platform/integration/tripub.md
@@ -282,11 +281,12 @@ pages:
       - Deprecated:
         - Amazon ECR: platform/integration/aws-ecr.md
         - Amazon Web Services: platform/integration/aws.md
+        - Email: platform/integration/email.md
+        - IRC: platform/integration/irc.md
         - JFrog Artifactory: platform/integration/jfrog-artifactory.md
         - PEM Keys: platform/integration/key-pem.md
-        - SSH Keys: platform/integration/key-ssh.md
         - Quay.io: platform/integration/quay.md
-        - Email: platform/integration/email.md
+        - SSH Keys: platform/integration/key-ssh.md
     - Runtime:
       - Overview: platform/runtime/overview.md
       - Operating System:

--- a/sources/ci/email-notifications.md
+++ b/sources/ci/email-notifications.md
@@ -43,7 +43,7 @@ Check our blog ["Notifying CI failure/success status on Email and Slack"](http:/
 
 ###1. Limiting branches
 
-By default, Slack notifications are sent for builds for all branches. If you want to only send notifications for specific branch(es), you can do so with the `branches` keyword.
+By default, email notifications are sent for builds for all branches. If you want to only send notifications for specific branch(es), you can do so with the `branches` keyword.
 
 ```yaml
 integrations:                               

--- a/sources/ci/irc-notifications.md
+++ b/sources/ci/irc-notifications.md
@@ -9,19 +9,14 @@ page_keywords: irc, Continuous Integration, Continuous Deployment, CI/CD, testin
 
 You can send IRC notifications for various events in your CI workflow, including when builds start or finish.
 
-##Setup
-
-Before you start, you will need to connect your IRC account with Shippable so we have the credentials to send notifications on your behalf. We do this through [Account Integrations](/platform/integration/overview/), so that any sensitive information is abstracted from your config file. Once you add an account integration, you can use it for all your projects without needing to add it again.
-
 ##Basic config
 
-Once you have completed the Setup steps, you are ready to configure your `shippable.yml` to send IRC notifications. The basic configuration looks like this:
-
+The basic configuration looks like this:
 
 ```
 integrations:
   notifications:
-    - integrationName: irc-integration
+    - integrationName: irc
       type: irc
       recipients:
         - "chat.freenode.net#channel1"
@@ -29,23 +24,23 @@ integrations:
 ```
 Use the descriptions of each field below to modify the `yml` and tailor it to your requirements.
 
-- `integrationName` value is the name of the IRC integration you added to your settings. It is important the name matches exactly. If not, the build will fail with error as [described here](/ci/troubleshooting/#integration-name-specified-in-yml-does-not-match).
+- `integrationName` value is always `irc` since no account or subscription integration is required.
 - `type` is `irc`.
 - `recipients` is an array that specifies the channels you want to send the notification to. If there is just a single recipient, use the format `recipients: "chat.freenode.net#channel1"`
 
-And you're done. You will receive IRC notifications for all branches when builds fail, or change from failed to passed, or pull requests are built. To change some of these default configs, please see the Advanced config section below.
+And you're done. You will receive IRC notifications for all branches when builds fail, or change from failed to passed, or pull requests are built. To change some of these default configs, please see the advanced config section below.
 
 
 ##Advanced config
 
 ###1. Limiting branches
 
-By default, IRC notifications are sent for builds for all branches. If you want to only send notifications for specific branch(es), you can do so with the `branches` keyword.
+By default, IRC notifications are sent for builds for all branches. If you want to only send notifications for specific branches, you can do so with the `branches` keyword.
 
 ```
 integrations:                               
   hub:
-    - integrationName: irc-integration     #replace with your integration name   
+    - integrationName: irc   
       type: irc  
       recipients:
         - "chat.freenode.net#channel1"
@@ -55,7 +50,7 @@ integrations:
           - master
 ```
 
-`branches` allows you to choose the branches you want to send notifications for. The `only` tag should be used when you want to send notifications for builds of specific branches. You can also use the `except` tag to exclude specific branches. Wildcards are also supported.
+`branches` allows you to choose the branches for which you want to send notifications. The `only` tag should be used when you only want to send notifications for builds of specific branches. You can also use the `except` tag to exclude specific branches. Wildcards are also supported.
 
 
 ###2. Customizing notification triggers
@@ -64,7 +59,7 @@ By default, IRC notifications are sent for the following events:
 
 - <i class="ion-ios-minus-empty"></i> A build fails
 - <i class="ion-ios-minus-empty"></i> Build status for a project changes from failed to passed
-- <i class="ion-ios-minus-empty"></i> A Pull request is built
+- <i class="ion-ios-minus-empty"></i> A pull request is built
 
 <br>
 You can further customize these defaults with the following config:
@@ -72,7 +67,7 @@ You can further customize these defaults with the following config:
 ```
 integrations:                               
   hub:
-    - integrationName: irc-integration     #replace with your integration name   
+    - integrationName: irc
       type: irc  
       recipients:
         - "chat.freenode.net#channel1"
@@ -98,8 +93,6 @@ If you do not specify any of these tags, the defaults are: `on_success` is set t
 ##Removing IRC notifications
 
 To stop sending IRC notifications, simply remove the configuration from the `shippable.yml` for that project.
-
-If you are not using your IRC notification anywhere else, you can delete it from your Account Integrations list as well.
 
 ## Improve this page
 

--- a/sources/platform/integration/irc.md
+++ b/sources/platform/integration/irc.md
@@ -3,7 +3,15 @@ main_section: Platform
 sub_section: Integrations
 page_title: IRC integration
 
-# IRC Integration
+# IRC Integration (Deprecated)
+
+## Deprecation Note
+This integration has been deprecated. You can get IRC notifications in [CI](/ci/irc-notifications/) and [assembly lines](/platform/workflow/resource/notification/) by specifying recipients in yml files.
+
+If you have any existing IRC account integrations, you _can_ continue to use them.
+
+---
+
 
 As of this time, Shippable only supports public IRC rooms, so you do not need an account integration to connect and send notifications to your IRC rooms.
 
@@ -15,7 +23,6 @@ As of this time, Shippable only supports public IRC rooms, so you do not need an
 
 IRC can be used in the following [resources](/platform/workflow/resource/overview/):
 
-* [ciRepo](/platform/workflow/resource/cirepo)
 * [notification](/platform/workflow/resource/notification)
 
 ## Further Reading

--- a/sources/platform/tutorial/server/install-onebox.md
+++ b/sources/platform/tutorial/server/install-onebox.md
@@ -191,7 +191,7 @@ Sends email notifications and will only be started if there is an email provider
 Sends Hipchat notifications and will only run if Hipchat is selected in the add-ons panel.
 
 #### irc
-Sends IRC notifications and will only run if IRC is selected in the add-ons panel.
+Sends IRC notifications and will only run if IRC is selected in the install panel.
 
 #### jSync
 Updates `jenkins` pipeline jobs and will only run if Jenkins is selected in the add-ons panel.


### PR DESCRIPTION
#644 

Notes that IRC integrations are deprecated, alphabetizes the deprecated integrations list, and updates CI with IRC documentation to remove the IRC integration.