### PR TITLE
Correct shippable docs for postgis install

### DIFF
--- a/sources/ci/postgresql.md
+++ b/sources/ci/postgresql.md
@@ -54,13 +54,15 @@ env:
 ```
 
 ###Using Postgis
-We do not have Postgis installed on our official build images. If you want to use it for your build, you will need to install and activate it in your yml:
+We do not have Postgis installed on our official build images. If you want to use it for your build, you will need to install and activate it in your yml.  Check the SHIPPABLE_POSTGRES_VERSION matches the postgis version your are installing.
 
 ```
 build:
   ci:
-    - sudo apt-get install postgresql-9.3-postgis
-    - psql -U postgres -c "create extension postgis"
+    - echo $SHIPPABLE_POSTGRES_VERSION
+    - sudo apt-get install postgresql-9.6-postgis-2.3
+    - psql -U postgres -c 'create database your_database_name;'
+    - psql -U postgres -d your_database_name -c "create extension postgis;"
 ```
 
 ## Improve this page

--- a/sources/ci/postgresql.md
+++ b/sources/ci/postgresql.md
@@ -54,14 +54,14 @@ env:
 ```
 
 ###Using Postgis
-We do not have Postgis installed on our official build images. If you want to use it for your build, you will need to install and activate it in your yml.  Check the SHIPPABLE_POSTGRES_VERSION matches the postgis version your are installing.
+We do not have Postgis installed on our official build images. If you want to use it for your build, you will need to install and activate it in your yml.  Check the SHIPPABLE_POSTGRES_VERSION matches the postgis version you are installing.
 
 ```
 build:
   ci:
     - echo $SHIPPABLE_POSTGRES_VERSION
     - sudo apt-get install postgresql-9.6-postgis-2.3
-    - psql -U postgres -c 'create database your_database_name;'
+    - psql -U postgres -c "create database your_database_name;"
     - psql -U postgres -d your_database_name -c "create extension postgis;"
 ```
 


### PR DESCRIPTION
When attempting to install postgis on my shippable ci container I discovered the docs were incomplete.  The changes below reflect the changes I had to make to successfully install postgis on the latest shippable version.

Thanks
Iain