### PR TITLE
mark Trusted Docker Registry integration as deprecated & update links…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -266,7 +266,6 @@ pages:
       - Docker Cloud: platform/integration/docker-cloud.md
       - Docker Datacenter: platform/integration/docker-datacenter.md
       - Docker Registry: platform/integration/dockerRegistryLogin.md
-      - Docker Trusted Registry: platform/integration/docker-trusted-registry.md
       - Event Trigger: platform/integration/event-trigger.md
       - Git Credential: platform/integration/git-credential.md
       - GitHub: platform/integration/github.md
@@ -300,6 +299,7 @@ pages:
         - SSH Keys: platform/integration/key-ssh.md
         - Private Registries: platform/integration/docker-private-registry.md
         - Docker Hub: platform/integration/docker-hub.md
+        - Docker Trusted Registry: platform/integration/docker-trusted-registry.md
     - Runtime:
       - Overview: platform/runtime/overview.md
       - Machine image:

--- a/sources/ci/push-docker-hub.md
+++ b/sources/ci/push-docker-hub.md
@@ -10,7 +10,7 @@ You can push your image to Docker Hub in any section [of your yml](/ci/yml-struc
 
 Before you start, you will need to connect your Docker Hub account with Shippable so we have the credentials to push your image on your behalf.
 
-To add the Docker hub account, please follow steps [here](/platform/integration/docker-hub/#docker-hub-integration). Once you add an account integration, you can use it for all your projects without needing to add it again.
+To add the Docker hub account, please follow steps [here](/platform/integration/dockerRegistryLogin). Once you add an account integration, you can use it for all your projects without needing to add it again.
 
 ##Basic config
 
@@ -21,7 +21,7 @@ authenticate with Docker Hub using your credentials.
 integrations:                               
   hub:
     - integrationName: myIntegration    #replace with your integration name   
-      type: docker                        
+      type: dockerRegistryLogin                        
 ```
 
 3. Push to Docker hub in your `shippable.yml` file:
@@ -47,7 +47,7 @@ build:
 integrations:                               
   hub:
     - integrationName: myIntegration    #replace with your integration name   
-      type: docker    
+      type: dockerRegistryLogin    
       branches:
         only:
           - master
@@ -68,13 +68,13 @@ build:
 integrations:                               
   hub:
     - integrationName: master-DockerHub    #replace with your integration name   
-      type: docker    
+      type: dockerRegistryLogin    
       branches:
         only:
           - master
 
     - integrationName: dev-DockerHub    #replace with your integration name   
-      type: docker    
+      type: dockerRegistryLogin    
       branches:
         only:
           - dev
@@ -95,7 +95,7 @@ build:
 integrations:                               
   hub:
     - integrationName: myIntegration    #replace with your integration name   
-      type: docker              
+      type: dockerRegistryLogin              
 ```
 
 The environment variable `$SHIPPABLE_CONTAINER_NAME` contains the name of your CI container.
@@ -114,7 +114,7 @@ build:
 integrations:                               
   hub:
     - integrationName: myIntegration    #replace with your integration name   
-      type: docker
+      type: dockerRegistryLogin
 
 ```
 ## Sample project

--- a/sources/ci/push-docker-registry.md
+++ b/sources/ci/push-docker-registry.md
@@ -37,7 +37,7 @@ authenticate with Docker registry using your credentials
 integrations:
   hub:
     - integrationName: docker-registry-integration    #replace with your integration name
-      type: "dockerRegistryLogin"
+      type: dockerRegistryLogin
 ```
 
 You can replace your docker-registry-integration, image-name and image-tag as required in the snippet above.
@@ -56,7 +56,7 @@ build:
 integrations:
   hub:
     - integrationName: docker-registry-integration    #replace with your integration name
-      type: "dockerRegistryLogin"
+      type: dockerRegistryLogin
       branches:
         only:
           - master
@@ -77,13 +77,13 @@ build:
 integrations:
   hub:
     - integrationName: master-docker-registry    #replace with your integration name
-      type: "dockerRegistryLogin"
+      type: dockerRegistryLogin
       branches:
         only:
           - master
 
     - integrationName: dev-docker-registry    #replace with your integration name
-      type: "dockerRegistryLogin"
+      type: dockerRegistryLogin
       branches:
         only:
           - dev
@@ -104,7 +104,7 @@ build:
 integrations:
   hub:
     - integrationName: docker-registry-integration    #replace with your integration name
-      type: "dockerRegistryLogin"
+      type: dockerRegistryLogin
 ```
 
 The environment variable `$SHIPPABLE_CONTAINER_NAME` contains the name of your CI container.
@@ -123,7 +123,7 @@ build:
 integrations:
   hub:
     - integrationName: docker-registry-integration    #replace with your integration name
-      type: "dockerRegistryLogin"
+      type: dockerRegistryLogin
 
 ```
 

--- a/sources/getting-started/what-is-supported.md
+++ b/sources/getting-started/what-is-supported.md
@@ -132,8 +132,7 @@ Shippable supports a multitude of integrations into external providers. This mak
 
 ### Artifact Repositories
 
-- [Docker Hub](/platform/integration/dockerRegistryLogin)
-- [Docker Trusted Registry](/platform/integration/dockerRegistryLogin)
+- [Docker Registries](/platform/integration/dockerRegistryLogin)
 - [AWS Elastic Container Registry](/platform/integration/aws-keys)
 - [Google Container Registry](/platform/integration/gcloudKey)
 - [Quay](/platform/integration/quayLogin)

--- a/sources/platform/integration/docker-hub.md
+++ b/sources/platform/integration/docker-hub.md
@@ -14,7 +14,7 @@ Since this integration has been deprecated, you cannot create new account integr
 ## Usage in CI
 
 * [Using a custom image for CI](/ci/custom-docker-image/)
-* [Pushing artifacts to Docker Hub](/ci/push-to-docker-hub/)
+* [Pushing artifacts to Docker Hub](/ci/push-docker-hub/)
 
 ## Usage in Assembly Lines
 

--- a/sources/platform/integration/docker-hub.md
+++ b/sources/platform/integration/docker-hub.md
@@ -5,6 +5,13 @@ page_title: Docker Hub integration (Deprecated)
 
 # Docker Hub Integration (Deprecated)
 
+## Deprecation Note
+This integration has been deprecated. A new integration called [Docker Registry](/platform/integration/dockerRegistryLogin) has been introduced which can be used instead. It aims to simplify and unify existing Docker Hub, Docker Private/Trusted Registry functionalities.
+
+If you have any existing Docker Hub account integrations, you can continue to use them.
+
+---
+
 The [Docker Hub](https://hub.docker.com/) Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Hub so that you can pull and push Docker images.
 
 ## Adding account integration

--- a/sources/platform/integration/docker-private-registry.md
+++ b/sources/platform/integration/docker-private-registry.md
@@ -5,6 +5,13 @@ page_title: Docker Private Registry integration (Deprecated)
 
 # Docker Private Registry Integration (Deprecated)
 
+## Deprecation Note
+This integration has been deprecated. A new integration called [Docker Registry](/platform/integration/dockerRegistryLogin) has been introduced which can be used instead. It aims to simplify and unify existing Docker Hub, Docker Private/Trusted Registry functionalities.
+
+If you have any existing Docker Private Registry account integrations, you can continue to use them.
+
+---
+
 The [Docker Private Registry](https://docs.docker.com/registry/deploying/) Integration is used to connect Shippable DevOps Assembly Lines platform to a privately hosted Docker Hub so that you can pull and push Docker images.
 
 ## Adding account integration

--- a/sources/platform/integration/docker-trusted-registry.md
+++ b/sources/platform/integration/docker-trusted-registry.md
@@ -5,6 +5,13 @@ page_title: Docker Trusted Registry integration (Deprecated)
 
 # Docker Trusted Registry Integration (Deprecated)
 
+## Deprecation Note
+This integration has been deprecated. A new integration called [Docker Registry](/platform/integration/dockerRegistryLogin) has been introduced which can be used instead. It aims to simplify and unify existing Docker Hub, Docker Private/Trusted Registry functionalities.
+
+If you have any existing Docker Trusted Registry account integrations, you can continue to use them.
+
+---
+
 The **Docker Trusted Registry** Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Trusted Registry so that you can pull and push Docker images.
 
 ## Adding account integration

--- a/sources/platform/integration/docker-trusted-registry.md
+++ b/sources/platform/integration/docker-trusted-registry.md
@@ -1,30 +1,20 @@
-page_main_title: Docker Trusted Registry
+page_main_title: Docker Trusted Registry (Deprecated)
 main_section: Platform
 sub_section: Integrations
-page_title: Docker Private/Trusted Registry integration
+page_title: Docker Trusted Registry integration (Deprecated)
 
-# Docker Trusted Registry Integration
+# Docker Trusted Registry Integration (Deprecated)
 
 The **Docker Trusted Registry** Integration is used to connect Shippable DevOps Assembly Lines platform to Docker Trusted Registry so that you can pull and push Docker images.
 
 ## Adding account integration
 
-You can add this account integration by following steps on the [Adding an account integration](/platform/management/integrations/#adding-an-account-integration) page.
-
-Here is the information you need to create this integration:
-
-* **Integration Family** -- **hub**
-* **Integration type** -- **Docker Private Registry**
-* **Name** -- choose a friendly name for the integration
-* **URL** -- location of your private registry. Format `https://foo.com`
-* **Username** -- login to your Docker Registry Account
-* **Password** -- password of your Docker Registry Account
-* **Email** -- email of your Docker Registry Account
+Since this integration has been deprecated, you cannot create new account integrations for this, you can only edit/delete the exisiting Docker Private Registry integrations. You can use the new [Docker Registry](/platform/integration/dockerRegistryLogin) instead.
 
 ## Usage in CI
 
 * [Using a custom image for CI](/ci/custom-docker-image/)
-* [Pushing artifacts to Docker Hub](/ci/push-docker-private-registry/)
+* [Pushing artifacts to Docker Hub](/ci/push-docker-registry/)
 
 ## Usage in Assembly Lines
 

--- a/sources/platform/integration/jfrog-artifactory.md
+++ b/sources/platform/integration/jfrog-artifactory.md
@@ -1,9 +1,16 @@
-page_main_title: JFrog Artifactory
+page_main_title: JFrog Artifactory (Deprecated)
 main_section: Platform
 sub_section: Integrations
-page_title: JFrog Artifactory integration
+page_title: JFrog Artifactory integration (Deprecated)
 
-# JFrog Artifactory Integration
+# JFrog Artifactory Integration (Deprecated)
+
+## Deprecation Note
+This integration has been deprecated. A new integration called [JFrog artifactoryKey](/platform/integration/jfrog-artifactoryKey) has been introduced which can be used instead.
+
+If you have any existing JFrog Artifactory account integrations, you can continue to use them.
+
+---
 
 [JFrog Artifactory](https://www.jfrog.com/artifactory/) Integration is used to connect Shippable DevOps Assembly Lines platform to JFrog Artifactory so that you can pull and push artifacts, including Docker images.
 

--- a/sources/platform/integration/key-pem.md
+++ b/sources/platform/integration/key-pem.md
@@ -5,6 +5,13 @@ page_title: PEM integration (Deprecated)
 
 # PEM Key Integration (Deprecated)
 
+## Deprecation Note
+This integration has been deprecated. A new integration called [PEM Key](/platform/integration/pemKey) of type generic has been introduced which can be used instead.
+
+If you have any existing PEM Key account integrations of type hub, you can continue to use them.
+
+---
+
 The PEM Key Integration is used to connect Shippable DevOps Assembly Lines platform to VMs that allow PEM based auth. This is typically used to SSH in and then run activities on the machine. Tools like Terraform and Ansible use this to execute scripts on a machine.
 
 ## Adding account integration

--- a/sources/platform/integration/key-ssh.md
+++ b/sources/platform/integration/key-ssh.md
@@ -5,6 +5,13 @@ page_title: SSH keys integration (Deprecated)
 
 # SSH Keys Integration (Deprecated)
 
+## Deprecation Note
+This integration has been deprecated. A new integration called [sshKey](/platform/integration/sshKey) of type generic has been introduced which can be used instead.
+
+If you have any existing SSH Key account integrations of type hub, you can continue to use them.
+
+---
+
 **SSH Key** Integration is used to connect Shippable DevOps Assembly Lines platform to VMs that allow SSH based auth. This is typically used to SSH in and then run activities on the machine. Tools like Terraform and Ansible use this to execute scripts on a machine.
 
 ## Adding account integration

--- a/sources/platform/integration/quay.md
+++ b/sources/platform/integration/quay.md
@@ -5,6 +5,13 @@ page_title: Quay integration (Deprecated)
 
 # Quay Integration (Deprecated)
 
+## Deprecation Note
+This integration has been deprecated. A new integration called [Quay.io quayLogin](/platform/integration/quayLogin) of type generic has been introduced which can be used instead.
+
+If you have any existing Quay account integrations of type hub, you can continue to use them.
+
+---
+
 The [CoreOs Quay](https://quay.io/) Integration is used to connect Shippable DevOps Assembly Lines platform to Quay Docker Registry so that you can pull and push Docker images.
 
 ## Adding account integration

--- a/sources/platform/workflow/job/runcli.md
+++ b/sources/platform/workflow/job/runcli.md
@@ -115,13 +115,11 @@ integration. Here is a list of the tools configured for each integration type:
 | ------------------------------------|-------------|
 | AWS                                 | [AWS CLI](https://aws.amazon.com/cli/); [EB (Elastic Beanstalk) CLI](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html) |
 | Amazon EC2 Container Registry (ECR) | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
-| Docker Hub                          | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
-| Docker Trusted Registry             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
+| Docker Registry             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
 | Google Container Engine             | [gcloud](https://cloud.google.com/sdk/gcloud/); [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) |
 | Google Container Registry (GCR)     | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
 | JFrog Artifactory                   | [JFrog CLI](https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory) |
 | Kubernetes                          | [kubectl](https://kubernetes.io/docs/user-guide/kubectl/) |
-| Private Docker Registry             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
 | Quay.io                             | [Docker Engine](https://docs.docker.com/engine/platform/commandline/docker/) |
 
 

--- a/sources/platform/workflow/job/runsh.md
+++ b/sources/platform/workflow/job/runsh.md
@@ -91,9 +91,7 @@ Here is a list of the tools configured for each integration type:
 | [AWS Keys](/platform/integration/aws-keys) | [AWS](/platform/runtime/machine-image/cli-versions/#aws) & [Elastic Beanstalk](platform/runtime/machine-image/cli-versions/#aws-elastic-beanstalk) |
 | [AWS Keys with ECR scope](/platform/integration/aws-keys) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
 | [Azure](/platform/integration/azure) | [Azure](/platform/runtime/machine-image/cli-versions/#azure) |
-| [Docker Hub](/platform/integration/docker-hub) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
-| [Docker Private Registry](/platform/integration/docker-private-registry) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
-| [Docker Trusted Registry](/platform/integration/docker-trusted-registry) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
+| [Docker Registry](/platform/integration/dockerRegistryLogin) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
 | [Google Container Engine](/platform/integration/gke) | [Google Cloud](/platform/runtime/machine-image/cli-versions/#gke) & [Kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
 | [Google Cloud with GCR scope](/platform/integration/gcloudKey) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
 | [JFrog](/platform/integration/jfrog-artifactoryKey) | [JFrog](/platform/runtime/machine-image/cli-versions/#jfrog) |

--- a/sources/platform/workflow/resource/cliconfig.md
+++ b/sources/platform/workflow/resource/cliconfig.md
@@ -81,11 +81,9 @@ integration. Here is a list of the tools configured for each integration type:
 | ------------------------------------|-------------|
 | AWS                                 | [AWS CLI](/platform/runtime/machine-image/cli-versions/#aws); [AWS Elastic Beanstalk CLI](/platform/runtime/machine-image/cli-versions/#aws-elastic-beanstalk) |
 | AWS with `ecr` scope                | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
-| Docker Hub                          | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
-| Docker Private Registry             | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
-| Docker Trusted Registry             | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
+| Docker Registry                     | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
 | Google Container Engine             | [gcloud](/platform/runtime/machine-image/cli-versions/#gke); [kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
-| Google Cloud with `gcr` scope     | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
+| Google Cloud with `gcr` scope       | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
 | JFrog Artifactory                   | [JFrog CLI](/platform/runtime/machine-image/cli-versions/#jfrog) |
 | Kubernetes                          | [kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
 | Quay.io                             | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |


### PR DESCRIPTION
… to dockerRegistryLogin integration, add deprecation notice to ints

Fixes https://github.com/Shippable/docs/issues/679
Fixes https://github.com/Shippable/docs/issues/680