### PR TITLE
deprecate docs for GKE and point all links to the new gcloudKey integration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -273,7 +273,6 @@ pages:
       - GitHub Enterprise: platform/integration/github-enterprise.md
       - GitLab: platform/integration/gitlab.md
       - Google Cloud: platform/integration/gcloudKey.md
-      - Google Container Engine: platform/integration/gke.md
       - HipChat: platform/integration/hipchatKey.md
       - Jenkins: platform/integration/jenkins.md
       - JFrog Artifactory: platform/integration/jfrog-artifactoryKey.md
@@ -294,6 +293,7 @@ pages:
         - HipChat: platform/integration/hipchat.md
         - Google Cloud: platform/integration/gce.md
         - Google Container Registry: platform/integration/gcr.md
+        - Google Container Engine: platform/integration/gke.md
         - IRC: platform/integration/irc.md
         - JFrog Artifactory: platform/integration/jfrog-artifactory.md
         - PEM Keys: platform/integration/key-pem.md

--- a/sources/deploy/gke.md
+++ b/sources/deploy/gke.md
@@ -113,10 +113,10 @@ jobs:
 
 **Steps**
 
-1. Create an account integration for GKE in your Shippable UI. Instructions to create an integration are here:
+1. Create an account integration for Google Cloud in your Shippable UI. Instructions to create an integration are here:
 
     * [Adding an account integration](/platform/tutorial/integration/howto-crud-integration/)
-    * [GKE integration](/platform/integration/gke/)
+    * [Google cloud integration](/platform/integration/gcloudKey/)
 
     Copy the friendly name of the integration. We're using `op_int` for our sample snippet in the next step.
 
@@ -129,7 +129,7 @@ resources:
     type: cluster
     integration: op_int   # friendly name of the integration you created         
     pointer:
-      sourceName: "app-gke-cluster" # name of the actual cluster in GKE
+      sourceName: "app-google-cloud-cluster" # name of the actual cluster in GKE
 ```
 
 ###4. Create deployment job

--- a/sources/deploy/kube-multi-stage-deployments.md
+++ b/sources/deploy/kube-multi-stage-deployments.md
@@ -19,7 +19,7 @@ The main idea here is that we define the configuration and the deployment artifa
 
 ## Assumptions
 
-We assume that the application is already packaged as a Docker image. We have chosen GKE as our Docker registry, but you can use any Docker registry that [Shippable supports](/platform/integration/overview/#supported-docker-registry-integrations). If you want to know how to build, test and push a Docker image through CI to a Docker registry, these links will help:
+We assume that the application is already packaged as a Docker image. We have chosen Google Cloud as our Docker registry, but you can use any Docker registry that [Shippable supports](/platform/integration/overview/#supported-docker-registry-integrations). If you want to know how to build, test and push a Docker image through CI to a Docker registry, these links will help:
 
 * [Getting started with CI](/ci/why-continuous-integration/)
 * [CI configuration](/ci/yml-structure/)
@@ -233,11 +233,11 @@ resources:
 
 * **Description:** `dmsk_cliConfig` is a [cliConfig](/platform/workflow/resource/cliconfig/) resource which is a pointer to the private key of your service account needed to initialize the gcloud CLI.
 * **Required:** Yes.
-* **Integrations needed:** [GKE Integration](/platform/integration/gke/)
+* **Integrations needed:** [Google Cloud Integration](/platform/integration/gcloudKey/)
 
-**Steps**  
+**Steps**
 
-1. Create an account integration using your Shippable account for GKE. Instructions to create an integration can be found [here](http://docs.shippable.com/platform/tutorial/integration/howto-crud-integration/). Set the friendly name of the integration as `drship_gke`. If you change the name, please change it also in the yml below .
+1. Create an account integration using your Shippable account for Google Cloud. Instructions to create an integration can be found [here](http://docs.shippable.com/platform/tutorial/integration/howto-crud-integration/). Set the friendly name of the integration as `drship_gke`. If you change the name, please change it also in the yml below .
 
 2. Add the following yml block to your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file.
 
@@ -310,7 +310,7 @@ resources:
 
 * **Description:** `dmsk_test_cluster` and `dmsk_prod_cluster` are [cluster](/platform/workflow/resource/cluster/) resources that represents the Test/Prod Kubernetes clusters where your application is deployed to.
 * **Required:** Yes.
-* Integrations needed: [GKE](/platform/integration/gke/)
+* Integrations needed: [Google Cloud](/platform/integration/gcloudKey/)
 
 3. Add the following yml block to your [shippable.resources.yml](/platform/tutorial/workflow/shippable-resources-yml/) file.
 
@@ -319,7 +319,7 @@ resources:
 
   - name: dmsk_test_cluster
     type: cluster
-    integration: drship_gke    #replace with your GKE integration name
+    integration: drship_gke    #replace with your Google Cloud integration name
     pointer:
       sourceName: "dmsk-test-cluster"
       region: us-central1-b
@@ -327,7 +327,7 @@ resources:
 
   - name: dmsk_prod_cluster
     type: cluster
-    integration: drship_gke    #replace with your GKE integration name
+    integration: drship_gke    #replace with your Google Cloud integration name
     pointer:
       sourceName: "dmsk-prod-cluster"
       region: us-central1-a

--- a/sources/platform/integration/gce.md
+++ b/sources/platform/integration/gce.md
@@ -6,7 +6,7 @@ page_title: GCL integration (Deprecated)
 # Google Cloud Integration (Deprecated)
 
 ## Deprecation Note
-This integration has been deprecated. A new integration called [Google Cloud](/platform/integration/gcloudKey) has been introduced which can be used instead. It aims to simplify and unify existing GCR and GCL functionalities.
+This integration has been deprecated. A new integration called [Google Cloud](/platform/integration/gcloudKey) has been introduced which can be used instead. It aims to simplify and unify existing GCR, GKE and GCL functionalities.
 
 If you have any existing GCL integrations, you can continue to use them.
 

--- a/sources/platform/integration/gcr.md
+++ b/sources/platform/integration/gcr.md
@@ -6,9 +6,9 @@ page_title: GCR integration (Deprecated)
 # GCR integration (Deprecated)
 
 ## Deprecation Note
-This integration has been deprecated. A new integration called [Google Cloud](/platform/integration/gcloudKey) has been introduced which can be used instead. It aims to simplify and unify existing GCR and GCL functionalities.
+This integration has been deprecated. A new integration called [Google Cloud](/platform/integration/gcloudKey) has been introduced which can be used instead. It aims to simplify and unify existing GCR, GKE and GCL functionalities.
 
-If you have any existing GCL integrations, you can continue to use them.
+If you have any existing GCR integrations, you can continue to use them.
 
 ---
 

--- a/sources/platform/integration/gke.md
+++ b/sources/platform/integration/gke.md
@@ -1,20 +1,24 @@
-page_main_title: Google Container Engine
+page_main_title: Google Container Engine (Deprecated)
 main_section: Platform
 sub_section: Integrations
-page_title: GKE integration
+page_title: GKE integration (Deprecated)
 
-# Google Container Engine Integration
+# Google Container Engine Integration (Deprecated)
+
+## Deprecation Note
+This integration has been deprecated. A new integration called [Google Cloud](/platform/integration/gcloudKey) has been introduced which can be used instead. It aims to simplify and unify existing GCR, GKE and GCL functionalities.
+
+If you have any existing GKE integrations, you can continue to use them.
+
+---
 
 Available under the Integration Family: **deploy**
 
 `Google Container Engine` Integration is used to connect Shippable DevOps Assembly Lines platform to Google Container Engine that runs Kubernetes behind the scenes so that you can deploy Docker-based applications.
 
-You can create this from the integrations page by following instructions here: [Adding an account integration](/platform/management/integrations/#adding-an-account-integration).
+## Adding account integration
 
-This is the information you would require to create this integration:
-
-* **Name** -- friendly name for the integration
-* **JSON Key** -- JSON Security Key for Google Cloud
+Since this integration has been deprecated, you cannot create new account integrations for this, you can only edit/delete the exisiting GCR integrations. You can use the new [Google Cloud](/platform/integration/gcloudKey) instead.
 
 ## Resources that use this Integration
 Resources are the building blocks of assembly lines and some types of resources refer to integrations by their names. The following resource types can be created with a `Google Container Engine` integration.

--- a/sources/platform/integration/overview.md
+++ b/sources/platform/integration/overview.md
@@ -30,7 +30,7 @@ We are big believers in the concept that secrets need to be separated from scrip
 
 - [Amazon ECS](/platform/integration/amazon-ecs)
 - [Kubernetes](/platform/integration/kubernetes)
-- [Google Container Engine](/platform/integration/gke)
+- [Google Container Engine](/platform/integration/gcloudKey)
 - [Azure](/platform/integration/azure/)
 - [Azure DC/OS](/platform/integration/azure-dcos)
 - [Docker Cloud](/platform/integration/docker-cloud)

--- a/sources/platform/workflow/job/runsh.md
+++ b/sources/platform/workflow/job/runsh.md
@@ -92,12 +92,15 @@ Here is a list of the tools configured for each integration type:
 | [AWS Keys with ECR scope](/platform/integration/aws-keys) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
 | [Azure](/platform/integration/azure) | [Azure](/platform/runtime/machine-image/cli-versions/#azure) |
 | [Docker Registry](/platform/integration/dockerRegistryLogin) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
-| [Google Container Engine](/platform/integration/gke) | [Google Cloud](/platform/runtime/machine-image/cli-versions/#gke) & [Kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
+| [Google Cloud](/platform/integration/gcloudKey) | [Google Cloud](/platform/runtime/machine-image/cli-versions/#gke) & [Kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
+| [Google Cloud with GKE scope](/platform/integration/gcloudKey) | [Google Cloud](/platform/runtime/machine-image/cli-versions/#gke) & [Kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
 | [Google Cloud with GCR scope](/platform/integration/gcloudKey) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
 | [JFrog](/platform/integration/jfrog-artifactoryKey) | [JFrog](/platform/runtime/machine-image/cli-versions/#jfrog) |
 | [Kubernetes](/platform/integration/kubernetes) | [Kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
 | [Quay](/platform/integration/quayLogin) | [Docker](/platform/runtime/machine-image/cli-versions/#docker) |
 | For all Integrations above | [Packer](/platform/runtime/machine-image/cli-versions/#packer) & [Terraform](/platform/runtime/machine-image/cli-versions/#terraform)|
+
+**Note**: Google Cloud with `gke` scope is used to set the cluster name and region. For all other google cloud integration type(with no scopes or when scope is `gcr`) the cluster name and region will be ignored.
 
 ## Default Environment Variables
 In order to make it easier to write your scripts and work with `IN` and `OUT` resources, we have made several environment variables available for use within your `TASK` section of your `runSh` job. Visit the Resource page for each type, to get the list of environment variables that get set depending on the Resource type thats either `IN` or `OUT`

--- a/sources/platform/workflow/resource/cliconfig.md
+++ b/sources/platform/workflow/resource/cliconfig.md
@@ -26,7 +26,6 @@ resources:
 	* [AWS Keys](/platform/integration/aws-keys)
 	* [Docker Registry](/platform/integration/dockerRegistryLogin)
 	* [Google Cloud](/platform/integration/gcloudKey)
-	* [Google Container Engine](/platform/integration/gke)
 	* [JFrog Artifactory](/platform/integration/jfrog-artifactoryKey)
 	* [Kubernetes](/platform/integration/kubernetes)
 	* [Quay](/platform/integration/quayLogin)
@@ -49,11 +48,23 @@ resources:
                   - TASK:
                     - script: ls
 
-	* For Google integrations, if region and clusterName are provided `gcloud` and `kubectl` will be automatically configured to use that region and cluster. If not provided, just the authentication to Google Cloud is done automatically.
+	* For Google integrations, if no scopes are mentioned just the authentication to Google Cloud is done automatically. If no scopes are passed then, the region and cluster name will be ignored.
 
 	        pointer:
 	          region:      <region, e.g., us-central1-a, us-west1-b, etc.>
 	          clusterName: <cluster name>
+
+      * If you need the CLI to also configure GKE, you need to pass it in as a scope in the job. if region and clusterName are provided `gcloud` and `kubectl` will be automatically configured to use that region and cluster.  Example:
+
+            jobs:
+              - name: runSh-success-1
+                type: runSh
+                steps:
+                  - IN: gcloud-key-integration
+                    scopes:
+                      - gke
+                  - TASK:
+                    - script: ls
 
       * If you need the CLI to also configure GCR, you need to pass it in as a scope in the job. However, if you pass `scopes` as gcr as below the region and cluster even, if provided will be ignored.  Example:
 
@@ -66,6 +77,7 @@ resources:
                       - gcr
                   - TASK:
                     - script: ls
+
 
 <a name="cliConfigTools"></a>
 ## Configured CLI tools
@@ -80,11 +92,14 @@ integration. Here is a list of the tools configured for each integration type:
 | AWS                                 | [AWS CLI](/platform/runtime/machine-image/cli-versions/#aws); [AWS Elastic Beanstalk CLI](/platform/runtime/machine-image/cli-versions/#aws-elastic-beanstalk) |
 | AWS with `ecr` scope                | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
 | Docker Registry                     | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
-| Google Container Engine             | [gcloud](/platform/runtime/machine-image/cli-versions/#gke); [kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
+| Google Cloud                        | [gcloud](/platform/runtime/machine-image/cli-versions/#gke); [kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
+| Google Cloud with `gke` scope       | [gcloud](/platform/runtime/machine-image/cli-versions/#gke); [kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
 | Google Cloud with `gcr` scope       | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
 | JFrog Artifactory                   | [JFrog CLI](/platform/runtime/machine-image/cli-versions/#jfrog) |
 | Kubernetes                          | [kubectl](/platform/runtime/machine-image/cli-versions/#kubectl) |
 | Quay.io                             | [Docker Engine](/platform/runtime/machine-image/cli-versions/#docker) |
+
+**Note**: Google Cloud with `gke` scope is used to configure the cluster name and region. For all other google cloud integration type(with no scopes or when scope is `gcr`) the cluster name and region will be ignored.
 
 ## Used in Jobs
 This resource is used as an `IN` for the following jobs

--- a/sources/platform/workflow/resource/cluster.md
+++ b/sources/platform/workflow/resource/cluster.md
@@ -28,7 +28,7 @@ resources:
 	* [Azure Container Service](/platform/integration/azure-dcos)
 	* [Docker Cloud](/platform/integration/docker-cloud)
 	* [Docker Datacenter](/platform/integration/docker-datacenter)
-	* [Google Container Engine (GKE)](/platform/integration/gke)
+	* [Google Google Cloud)](/platform/integration/gcloudKey)
 	* [Kubernetes](/platform/integration/kubernetes)
 	* [Node Cluster](/platform/integration/nodeCluster)
 	* [Joyent Triton](/platform/integration/tripub)
@@ -49,7 +49,7 @@ resources:
 
 	* For Docker Datacenter integrations - N/A
 	* For Kubernetes integrations - N/A
-	* For GKE integrations:
+	* For Google Cloud integrations:
 
 	        pointer:
 	          region:     <region, e.g., us-central1-a, us-west1-b, etc.>

--- a/sources/platform/workflow/resource/loadbalancer.md
+++ b/sources/platform/workflow/resource/loadbalancer.md
@@ -21,7 +21,7 @@ resources:
 * **`type`** -- is set to `loadBalancer`
 
 * **`integration`** -- name of the subscription integration, i.e. the name of your integration at `https://app.shippable.com/subs/[github or bitbucket]/[Subscription name]/integrations`. The integration is only used when this resource is an input for a [provision](/platform/workflow/job/provision) job. Currently supported integration types are:
-	* [Google Container Engine (GKE)](/platform/integration/gke)
+	* [Google Cloud](/platform/integration/gcloudKey)
 
 * **`pointer`** -- is an object that contains provider specific properties
 	* For [AWS Classic Load Balancers](https://aws.amazon.com/elasticloadbalancing/classicloadbalancer/),
@@ -42,7 +42,7 @@ resources:
 
 	    Note: `role` is and optional setting and if set, the role should have trust relationship allowing "ecs.amazonaws.com", if this is left blank, Shippable will search for one that has the right level of trust automatically. If none is found, the job where this resource is used will fail.
 
-	* For [GKE Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs,
+	* For [Google Cloud Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs,
 
 	        pointer:
 	          sourceName:           <lowercase alphanumeric name only>

--- a/sources/provision/kubernetes-with-gkecli.md
+++ b/sources/provision/kubernetes-with-gkecli.md
@@ -76,7 +76,7 @@ resources:
 
 * **Description:** `gke_cliConfig` is a [cliConfig](/platform/workflow/resource/cliconfig/) resource which is a pointer to the private key of your service account needed to initialize the gcloud CLI.
 * **Required:** Yes.
-* **Integrations needed:** [GKE Integration](/platform/integration/gke/)
+* **Integrations needed:** [Google Cloud Integration](/platform/integration/gcloudKey/)
 
 **Steps**  
 


### PR DESCRIPTION

https://github.com/Shippable/docs/issues/697