### PR TITLE
add back node cluster to deprecated

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -301,6 +301,7 @@ pages:
         - Quay.io: platform/integration/quay.md
         - Slack: platform/integration/slack.md
         - SSH Keys: platform/integration/key-ssh.md
+        - Node Cluster: platform/integration/node-cluster.md
     - Runtime:
       - Overview: platform/runtime/overview.md
       - Machine image:


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/9255

This was removed in this [commit](https://github.com/Shippable/docs/commit/2298c0748628a1f93a1e384f9f878bf9dc4f5b99#diff-45ee620855dad847bea76b49932ad7dbL304). But old CLUSTER integration needs to be in deprecated section.
