### PR TITLE
Update go-continuous-integration.md

### DIFF
--- a/sources/ci/go-continuous-integration.md
+++ b/sources/ci/go-continuous-integration.md
@@ -54,6 +54,7 @@ Our official build images, which are used to run your builds by default, come in
 -  1.6.4
 -  1.7
 -  1.7.5
+-  1.8
 
 To find out which versions are supported out of the box for your build image, read our [Machine images overview](/platform/tutorial/runtime/ami-overview/)
 
@@ -62,7 +63,7 @@ If you want to test against several versions of Go, you can specify multiple run
 ```
 go:
   - 1.6
-	- 1.7
+  - 1.7
 
 ```
 

--- a/sources/ci/go-continuous-integration.md
+++ b/sources/ci/go-continuous-integration.md
@@ -55,6 +55,7 @@ Our official build images, which are used to run your builds by default, come in
 -  1.7
 -  1.7.5
 -  1.8
+-  1.9
 
 To find out which versions are supported out of the box for your build image, read our [Machine images overview](/platform/tutorial/runtime/ami-overview/)
 


### PR DESCRIPTION
- add golang 1.8 to pre-installed list
- fix whitespace in multiple runtimes YAML example