### PR TITLE
#792; updates gcloudKey documentation to add bastionHost.

### DIFF
--- a/sources/deploy/gke.md
+++ b/sources/deploy/gke.md
@@ -5,7 +5,7 @@ sub_sub_section: GKE
 
 # Deploying to Google Container Engine (GKE)
 
-NOTE: [This page on Kubernetes](./kubernetes) describes the preferred way to deploy to a k8s cluster on Shippable, as it communicates directly with the cluster.  The Shippable `kubernetes` integration also utilizes `deployment` objects, while the `gke` integration uses `replicationControllers` (RC).
+NOTE: Deployments made with [Google Cloud integrations](/platform/integration/gcloudKey/) utilize `deployment` objects, while the deprecated [Google Container Engine integrations](/platform/integration/gke/) use `replicationControllers` (RC). Either integration can be used to deploy to GKE.
 
 There are many strategies that can be used to deploy containers to [GKE](https://cloud.google.com/container-engine/) using Shippable's Assembly Lines.  This page will describe how you can use the managed [**deploy job**](/platform/workflow/job/deploy/) to take a single Docker image and deploy it as an individual container to your cluster on GKE.
 
@@ -69,7 +69,7 @@ This file should be committed to your source control. Step 5 of the workflow bel
 1. Create an account integration for GCR in your Shippable UI. Instructions to create an integration are here:
 
     * [Adding an account integration](/platform/tutorial/integration/howto-crud-integration/) and
-    * [Google cloud integration](/platform/integration/gcloudKey/)
+    * [Google Cloud integration](/platform/integration/gcloudKey/)
 
     Copy the friendly name of the integration.
 
@@ -116,7 +116,7 @@ jobs:
 1. Create an account integration for Google Cloud in your Shippable UI. Instructions to create an integration are here:
 
     * [Adding an account integration](/platform/tutorial/integration/howto-crud-integration/)
-    * [Google cloud integration](/platform/integration/gcloudKey/)
+    * [Google Cloud integration](/platform/integration/gcloudKey/)
 
     Copy the friendly name of the integration. We're using `op_int` for our sample snippet in the next step.
 

--- a/sources/platform/workflow/resource/cluster.md
+++ b/sources/platform/workflow/resource/cluster.md
@@ -30,7 +30,7 @@ resources:
 	* [Amazon ECS](/platform/integration/aws-iam)
 	* [Docker Cloud](/platform/integration/dclKey)
 	* [Docker Datacenter](/platform/integration/ddcKey)
-	* [Google Cloud)](/platform/integration/gcloudKey)
+	* [Google Cloud](/platform/integration/gcloudKey)
 	* [Kubernetes](/platform/integration/kubernetes-config)
 	* [Node Cluster](/platform/integration/nodeCluster)
 	* [Joyent Triton](/platform/integration/joyentTritonKey)
@@ -65,6 +65,17 @@ resources:
 	          region:     <region, e.g., us-central1-a, us-west1-b, etc.>
 	          sourceName: <Google Container Engine cluster name>
 	          namespace:  <optional namespace you want to deploy to>
+
+        You can also specify a bastion host to use when connecting to the cluster in the pointer section:
+
+             pointer:
+               region:     <region, e.g., us-central1-a, us-west1-b, etc.>
+               sourceName: <Google Container Engine cluster name>
+               namespace:  <optional namespace you want to deploy to>
+               bastionHost:
+                 address:        <public address of your bastion host>
+                 user:           <bastionHost user>
+                 keyIntegration: <key_integration_resource> # Can be an sshKey or pemKey integration resource
 
 	* For Node Cluster integrations - N/A
 	* For Joyent Triton integrations,

--- a/sources/platform/workflow/resource/loadbalancer.md
+++ b/sources/platform/workflow/resource/loadbalancer.md
@@ -43,33 +43,7 @@ resources:
 
 	    Note: `role` is and optional setting and if set, the role should have trust relationship allowing "ecs.amazonaws.com", if this is left blank, Shippable will search for one that has the right level of trust automatically. If none is found, the job where this resource is used will fail.
 
-	* For [Google Cloud Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs,
-
-	        pointer:
-	          sourceName:           <lowercase alphanumeric name only>
-	          method:               ClusterIP | ExternalName | LoadBalancer | NodePort  #default is ClusterIP
-	          namespace:            <name of the namespace where pod is deployed>       #optional
-	          clusterName:          <name of the GKE cluster>
-	          region:               <name of the region>
-	        version:
-	          ports:
-	            - name:             <string>
-	              protocol:         TCP | UDP #default TCP
-	              port:             <integer>
-	              targetPort:       <string>
-	              nodePort:         <integer>
-	          selector:
-	            <string> : <string>
-	          clusterIP:            None | "" | <string>
-	          externalIPs:
-	            - <string>
-	          sessionAffinity:      ClientIP | None
-	          loadBalancerIP:       <string>
-	          loadBalancerSourceRanges:
-	            - <string>
-	          externalName:         <string>
-
-	* For [Kubernetes Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs,
+	* For [Google Cloud Load Balancers](https://kubernetes.io/docs/user-guide/services/) or [Kubernetes Load Balancers](https://kubernetes.io/docs/user-guide/services/) used in `provision` jobs,
 
 	        pointer:
 	          bastionHost: # If using bastion host for configuring kubernetes clusters
@@ -98,6 +72,8 @@ resources:
 	          loadBalancerSourceRanges:
 	            - <string>
 	          externalName:         <string>
+
+        Note: `bastionHost` is only supported for [Kubernetes](/platform/integration/kubernetes/) and [Google Cloud](/platform/integration/gcloudKey/) integrations. It will not work with a [Google Container Engine](/platform/integration/gke/) integration.
 
 ## Used in Jobs
 This resource is used as an `IN` for the following jobs:


### PR DESCRIPTION
#792 

Updates gcloudKeys documentation.  It now has the same options as Kubernetes in deploy and provision.