### PR TITLE
Fixed generic integration list item

### DIFF
--- a/sources/platform/tutorial/integration/howto-use-key-value-in-runci.md
+++ b/sources/platform/tutorial/integration/howto-use-key-value-in-runci.md
@@ -12,7 +12,7 @@ Adding the integration to your CI workflow is quite simple.  Just update your `s
 ```
 integrations:  # this section can contain several different types of integrations
   generic:     # k/v pair should be under the 'generic' header
-    integrationName: my-key-value-integration # whichever name you chose for your integration
+    - integrationName: my-key-value-integration # whichever name you chose for your integration
 ```
 
 Now when your CI runs, your key/value pairs will be exported as shell environment variables.


### PR DESCRIPTION
The documentation for adding a key-value pair to a CI job does not use the (required) list syntax. The current example results in a YML validation error.