### PR TITLE
Adds missing shipctl commands

### DIFF
--- a/sources/platform/tutorial/workflow/using-shipctl.md
+++ b/sources/platform/tutorial/workflow/using-shipctl.md
@@ -273,6 +273,24 @@ shipctl get_resource_meta <resource name>
 MY_RESOURCE_META="$(shipctl get_resource_meta "vpc_settings")"
 ```
 
+### get_resource_name
+
+**Description**
+
+Gets the sanitized name for a given resource or job. This command uses `sanitize_shippable_string` command internally.
+
+**Usage**
+
+```
+shipctl get_resource_name <resource name>
+```
+
+**Example**
+
+```
+MY_RES_NAME="$(shipctl get_resource_name "vpc_settings")"
+```
+
 ### get_resource_operation
 
 **Description**

--- a/sources/platform/tutorial/workflow/using-shipctl.md
+++ b/sources/platform/tutorial/workflow/using-shipctl.md
@@ -691,6 +691,13 @@ MY_UPPERCASE="$(shipctl to_uppercase "foo!@#")"
 
 Output of the above statement would be `FOO!@#`
 
+## Deprecated commands
+
+Following commands are deprecated and have alternate implementations introduced as of Shippable v5.11.1
+
+- get_resource_path - Use [get_resource_state](#get_resource_state) instead.
+- copy_resource_file_from_state - Use [copy_file_from_resource_state](#copy_file_from_resource_state) instead.
+- refresh_file_to_out_path - Use  [copy_file_to_resource_state](#copy_file_to_resource_state) instead.
 
 ## Further Reading
 * [Jobs](/platform/workflow/job/overview)

--- a/sources/platform/tutorial/workflow/using-shipctl.md
+++ b/sources/platform/tutorial/workflow/using-shipctl.md
@@ -500,6 +500,47 @@ jobs:
         - script: MY_INT_FIELD="$(shipctl get_integration_resource_field "myGkeCluster" "jsonkey")"
 ```
 
+### get_params_resource
+
+**Description**
+
+Gets the value for the given key present in an `IN` resource of type `params`.
+
+**Usage**
+
+```
+shipctl get_params_resource <resource name> <key name>
+```
+
+- `resource name` is the name of the `IN` resource
+- `key name` is the key defined in the params resource.
+
+**Example**
+
+Say you have [params](/platform/workflow/resource/params) resource **myParams**
+
+```
+resources:
+  - name: myParams
+    type: params
+    version:
+      params:
+        key1: "value1"
+        key2: "value2"
+```
+
+You can get the value of the key in **myParams** with the following:
+
+```
+jobs:
+  - name: myCustomJob
+    type: runSh
+    steps:
+      - IN: myParams
+      - TASK:
+        - script: MY_KEY1_VALUE="$(shipctl get_params_resource "myParams" "key1")"
+```
+
 ## Additional utilities
 
 ### decrypt

--- a/sources/platform/tutorial/workflow/using-shipctl.md
+++ b/sources/platform/tutorial/workflow/using-shipctl.md
@@ -522,7 +522,7 @@ jobs:
 
 **Description**
 
-Gets the value for the given key present in an `IN` resource of type `params`.
+Gets the value for the given key present in an `IN` resource of type `params`. All the key-value pairs in `params` resource are available as environment variables and could be conveniently accessed from there.
 
 **Usage**
 
@@ -543,8 +543,8 @@ resources:
     type: params
     version:
       params:
-        key1: "value1"
-        key2: "value2"
+        KEY1: "value1"
+        KEY2: "value2"
 ```
 
 You can get the value of the key in **myParams** with the following:
@@ -556,7 +556,8 @@ jobs:
     steps:
       - IN: myParams
       - TASK:
-        - script: MY_KEY1_VALUE="$(shipctl get_params_resource "myParams" "key1")"
+        - script: MY_KEY1_VALUE="$(shipctl get_params_resource "myParams" "KEY1")"
+        - script: echo "$KEY1"  # Key-value pair accessed via environment variable directly
 ```
 
 ## Additional utilities

--- a/sources/platform/tutorial/workflow/using-shipctl.md
+++ b/sources/platform/tutorial/workflow/using-shipctl.md
@@ -309,6 +309,24 @@ shipctl get_resource_operation <resource name>
 MY_RES_OPER="$(shipctl get_resource_operation "vpc_settings")"
 ```
 
+### get_resource_pointer_key
+
+**Description**
+
+Gets value for the given key present in the pointer of a `IN` resource.
+
+**Usage**
+
+```
+shipctl get_resource_pointer_key <resource name> <key name>
+```
+
+**Example**
+
+```
+MY_RES_POINTER="$(shipctl get_resource_pointer_key "myAWSCluster" "region")"
+```
+
 ### get_resource_state
 
 **Description**


### PR DESCRIPTION
https://github.com/Shippable/docs/issues/865

#### MIssing commands
- [x] get_resource_name
- [x] get_params_resource
- [x] get_resource_pointer_key

#### Deprecated commands
- [x] get_resource_path
- [x] copy_resource_file_from_state
- [x] refresh_file_to_out_path

Newer commands for deprecated commands are introduced from `v5.11.1`