### PR TITLE
Clarify default image for language:none

### DIFF
--- a/sources/ci/set-language.md
+++ b/sources/ci/set-language.md
@@ -14,7 +14,7 @@ language: node_js
 
 You can set this tag to the following values depending on the language you need for your build: `clojure`, `go`, `java`, `node_js`, `php`, `python`, `ruby`, `scala`, `c`.
 
-Specifying ```language: none``` in your yml skips any default language specific processing and will require you to specify a custom image for your build. Details are in the [building unsupported languages](unsupported-languages/) section of our docs.
+Specifying ```language: none``` in your yml skips any default language specific processing. You can use this configuration to run builds on the language of your choice using a custom Docker image. Details are in the [building unsupported languages](unsupported-languages/) section of our docs. If you do not specify a build image in the `pre_ci_boot` section of your yml, the `drydock/u16pytall` image will be used by default.
 
 ## runtime
 


### PR DESCRIPTION
Clarifies that `language: none` can be used to skip all default commands, and will use `drydock/u16pytall` by default if nothing is specified in `pre_ci_boot`.

![set_language](https://user-images.githubusercontent.com/1134972/35794396-9401b6f8-0a7b-11e8-870a-13ceddb5966d.png)

