### PR TITLE
#926; notes that gitRepo resources will not trigger when YML files are updated.

### DIFF
--- a/sources/platform/workflow/resource/gitrepo.md
+++ b/sources/platform/workflow/resource/gitrepo.md
@@ -4,7 +4,9 @@ sub_section: Workflow
 sub_sub_section: Resources
 
 # gitRepo
-`gitRepo` is used to connect DevOps Assembly Lines to source control repository. Adding it creates a webhook to the repo so that future commits will automatically create a new version with with webhook payload. This will trigger any jobs that have this resource as an `IN`.
+`gitRepo` is used to connect DevOps Assembly Lines to source control repository. Adding it creates a webhook to the repo so that future commits will automatically create a new version with the webhook payload.
+
+When a webhook is received, jobs that have this resource as an `IN` will usually be triggered.  Jobs will not be triggered for commit webhooks determined to have updated any `shippable.yml`, `shippable.resources.yml`, `shippable.jobs.yml` or `shippable.triggers.yml` files.
 
 You can create a `gitRepo` resource by [adding](/platform/tutorial/workflow/crud-resource#adding) it to `shippable.yml`.
 


### PR DESCRIPTION
#926 

This is the only location I found that stated that every version would trigger jobs.  Jobs with this resource as an input will now only be triggered, if it's a commit webhook, when none of the YML files have changed.

![screenshot from 2018-02-19 13 54 00](https://user-images.githubusercontent.com/5492015/36398703-38dd5662-157d-11e8-8086-ca4f3639fa9a.png)
