### PR TITLE
adds info for updates nodejs versions for 6.2.4 ami

### DIFF
--- a/sources/platform/runtime/machine-image/ami-v624.md
+++ b/sources/platform/runtime/machine-image/ami-v624.md
@@ -61,6 +61,7 @@ We have the following base images, one for each supported OS version.
 
  | OS           | Image                    | Link                                                                                                          | Language versions                                                 | Additional packages                                                                |
  |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------------------------------|
+ | Ubuntu 16.04 | drydock/u16nodall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u16nodall/)<br> [Github](https://github.com/dry-dock/u16nodall) | - 4.8.7<br>- 5.12.0<br>- 6.11.5<br>- 7.10.1<br>- 8.1.4<br>- 8.6.0 <br>- 9.5.0 | [Common components](#common-624)<br>nvm<br>Java 1.8.0<br>Ruby 2.3.3<br>Yarn 1.2.1 |
  | Ubuntu 14.04 | drydock/u14nodall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u14nodall/)<br>[Github](https://github.com/dry-dock/u14nodall)  | - 4.8.7 <br />- 5.12.0 <br />- 6.11.5 <br />- 7.10.1 <br />- 8.9.4 <br />- 9.5.0 | [Common components](#common-624)<br>nvm<br>Java 1.8.0<br>Ruby 2.3.3<br>Yarn 1.2.1 |
 
 ---


### PR DESCRIPTION
fixes: https://github.com/Shippable/docs/issues/965