### PR TITLE
#968; documents drydock/u16cloall:v6.2.4.

### DIFF
--- a/sources/platform/runtime/machine-image/ami-v624.md
+++ b/sources/platform/runtime/machine-image/ami-v624.md
@@ -62,8 +62,8 @@ We have the following base images, one for each supported OS version.
 
  | OS           | Image                    | Link                                                                                                          | Language versions                                                 | Additional packages                                                                |
  |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|------------------------------------------------------------------------------------|
- | Ubuntu 16.04 | drydock/u16nodall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u16nodall/)<br> [Github](https://github.com/dry-dock/u16nodall) | - 4.8.7<br>- 5.12.0<br>- 6.11.5<br>- 7.10.1<br>- 8.1.4<br>- 8.6.0 <br>- 9.5.0 | [Common components](#common-624)<br>nvm<br>Java 1.8.0<br>Ruby 2.3.3<br>Yarn 1.2.1 |
- | Ubuntu 14.04 | drydock/u14nodall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u14nodall/)<br>[Github](https://github.com/dry-dock/u14nodall)  | - 4.8.7 <br />- 5.12.0 <br />- 6.11.5 <br />- 7.10.1 <br />- 8.9.4 <br />- 9.5.0 | [Common components](#common-624)<br>nvm<br>Java 1.8.0<br>Ruby 2.3.3<br>Yarn 1.2.1 |
+ | Ubuntu 16.04 | drydock/u16nodall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u16nodall/)<br> [GitHub](https://github.com/dry-dock/u16nodall) | - 4.8.7<br>- 5.12.0<br>- 6.11.5<br>- 7.10.1<br>- 8.1.4<br>- 8.6.0 <br>- 9.5.0 | [Common components](#common-624)<br>nvm<br>Java 1.8.0<br>Ruby 2.3.3<br>Yarn 1.2.1 |
+ | Ubuntu 14.04 | drydock/u14nodall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u14nodall/)<br>[GitHub](https://github.com/dry-dock/u14nodall)  | - 4.8.7 <br />- 5.12.0 <br />- 6.11.5 <br />- 7.10.1 <br />- 8.9.4 <br />- 9.5.0 | [Common components](#common-624)<br>nvm<br>Java 1.8.0<br>Ruby 2.3.3<br>Yarn 1.2.1 |
 
 ---
 
@@ -72,7 +72,8 @@ We have the following base images, one for each supported OS version.
 
 | OS           | Image                    | Link                                                                                                          | Language versions                          | Additional packages                                                           |
 |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------|-------------------------------------------------------------------------------|
-| Ubuntu 14.04 | drydock/u14cloall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14cloall/),<br>- [GitHub](https://github.com/dry-dock/u14cloall) | - 1.3.0<br>- 1.4.0<br>- 1.5.1<br>- 1.6.0<br>- 1.7.0<br>- 1.8.0<br>- 1.9.0 | - [Common components](#common-614)<br>- leiningen<br>- Java 1.8<br>- Node 7.x<br>- Ruby 2.3.3 |
+| Ubuntu 16.04 | drydock/u16cloall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16cloall/),<br>- [GitHub](https://github.com/dry-dock/u16cloall) | - 1.3.0<br>- 1.4.0<br>- 1.5.1<br>- 1.6.0<br>- 1.7.0<br>- 1.8.0<br>- 1.9.0 | - [Common components](#common-624)<br>- leiningen<br>- Java 1.8<br>- Node 7.x<br>- Ruby 2.3.3 |
+| Ubuntu 14.04 | drydock/u14cloall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14cloall/),<br>- [GitHub](https://github.com/dry-dock/u14cloall) | - 1.3.0<br>- 1.4.0<br>- 1.5.1<br>- 1.6.0<br>- 1.7.0<br>- 1.8.0<br>- 1.9.0 | - [Common components](#common-624)<br>- leiningen<br>- Java 1.8<br>- Node 7.x<br>- Ruby 2.3.3 |
 
 ---
 
@@ -81,8 +82,9 @@ We have the following base images, one for each supported OS version.
 
  | OS   | Image  | Link   | Language versions  | Additional packages   |
  |------|--------|--------|--------------------|-----------------------|
- | Ubuntu 14.04 | drydock/u14golall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14golall/)<br>- [Github](https://github.com/dry-dock/u14golall) | - 1.7.6<br>- 1.8.5<br>- 1.9.2    | - [Common components](#common-624)<br>- gvm 1.0.22<br>- Java 1.8.10<br>- Node 4.8.7<br>- Ruby 2.3.3 |
- | Ubuntu 16.04 | drydock/u16golall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16golall/)<br>- [Github](https://github.com/dry-dock/u16golall) | - 1.7.6<br>- 1.8.5<br>- 1.9.2    | - [Common components](#common-624)<br>- gvm 1.0.22<br>- Java 1.8.10<br>- Node 7.10.1<br>- Ruby 2.3.5 | 
+ | Ubuntu 16.04 | drydock/u16golall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16golall/)<br>- [GitHub](https://github.com/dry-dock/u16golall) | - 1.7.6<br>- 1.8.5<br>- 1.9.2    | - [Common components](#common-624)<br>- gvm 1.0.22<br>- Java 1.8.10<br>- Node 7.10.1<br>- Ruby 2.3.5 |
+ | Ubuntu 14.04 | drydock/u14golall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14golall/)<br>- [GitHub](https://github.com/dry-dock/u14golall) | - 1.7.6<br>- 1.8.5<br>- 1.9.2    | - [Common components](#common-624)<br>- gvm 1.0.22<br>- Java 1.8.10<br>- Node 4.8.7<br>- Ruby 2.3.3 |
+
 
 ---
 
@@ -92,7 +94,7 @@ We have the following base images, one for each supported OS version.
 
  | OS           | Image                    | Link                                                                                                          | Language versions                                      | Additional packages                                         |
  |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|-------------------------------------------------------------|
- | Ubuntu 14.04 | drydock/u14javall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14javall/)<br>- [Github](https://github.com/dry-dock/u14javall) | - openjdk7<br>- openjdk8<br>- openjdk9<br>- oraclejdk8<br>- oraclejdk9           | - [Common components](#common-624)<br>- Node 4.8.7<br>- Ruby 2.3.3 <br>- Gradle 4.2.1 <br>- Android-sdk 26.0.1 (to be used with openjdk8/oraclejdk8) |
+ | Ubuntu 14.04 | drydock/u14javall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14javall/)<br>- [GitHub](https://github.com/dry-dock/u14javall) | - openjdk7<br>- openjdk8<br>- openjdk9<br>- oraclejdk8<br>- oraclejdk9           | - [Common components](#common-624)<br>- Node 4.8.7<br>- Ruby 2.3.3 <br>- Gradle 4.2.1 <br>- Android-sdk 26.0.1 (to be used with openjdk8/oraclejdk8) |
 
 ---
 
@@ -102,8 +104,8 @@ We have the following base images, one for each supported OS version.
 
  | OS           | Image                    | Link                                                                                                          | Language versions                                              | Additional packages                                                    |
  |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|------------------------------------------------------------------------|
- | Ubuntu 14.04 | drydock/u14ruball:v6.2.4 | <br>- [Docker Hub](https://hub.docker.com/r/drydock/u14ruball/),<br>- [Github](https://github.com/dry-dock/u14ruball) |- 2.2.8<br>- 2.3.6<br>- 2.4.3<br>- 2.5.0<br>- jruby-1.7.27<br>- jruby-9.1.15 | - [Common components](#common-614)<br>- rvm 1.29.3<br>- Java 1.8.0<br>- Node 4.8.7 |
-| Ubuntu 16.04 | drydock/u16ruball:v6.2.4 | <br>- [Docker Hub](https://hub.docker.com/r/drydock/u16ruball/),<br>- [Github](https://github.com/dry-dock/u16ruball) |- 2.2.9<br>- 2.3.6<br>- 2.4.3<br>- 2.5.0<br>- jruby-1.7.27<br>- jruby-9.1.15 | - [Common components](#common-614)<br>- rvm 1.29.3<br>- Java 1.8.0<br>- Node 7.10.1 |
+ | Ubuntu 16.04 | drydock/u16ruball:v6.2.4 | <br>- [Docker Hub](https://hub.docker.com/r/drydock/u16ruball/),<br>- [GitHub](https://github.com/dry-dock/u16ruball) |- 2.2.9<br>- 2.3.6<br>- 2.4.3<br>- 2.5.0<br>- jruby-1.7.27<br>- jruby-9.1.15 | - [Common components](#common-624)<br>- rvm 1.29.3<br>- Java 1.8.0<br>- Node 7.10.1 |
+ | Ubuntu 14.04 | drydock/u14ruball:v6.2.4 | <br>- [Docker Hub](https://hub.docker.com/r/drydock/u14ruball/),<br>- [GitHub](https://github.com/dry-dock/u14ruball) |- 2.2.8<br>- 2.3.6<br>- 2.4.3<br>- 2.5.0<br>- jruby-1.7.27<br>- jruby-9.1.15 | - [Common components](#common-624)<br>- rvm 1.29.3<br>- Java 1.8.0<br>- Node 4.8.7 |
 
 
 <a name="pyt-624"></a>
@@ -111,8 +113,8 @@ We have the following base images, one for each supported OS version.
 
  | OS           | Image                    | Link                                                                                                      | Language versions                                       | Additional packages                                                                 |
  |--------------|--------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------|-------------------------------------------------------------------------------------|
- | Ubuntu 16.04 | drydock/u16pytall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u16pytall/)<br> [Github](https://github.com/dry-dock/u16pytall) |- 2.7.12<br>- 3.4.8<br>- 3.5.2<br>- 3.6.4<br>- pypy2 5.10.0<br>- pypy3 5.10.1 | - [Common components](#common-614)<br>- virtualenv<br>- Java 1.8.0<br>- Node 7.10.0<br>- Ruby 2.3.3 |
- | Ubuntu 14.04 | drydock/u14pytall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14pytall/)<br>- [Github](https://github.com/dry-dock/u14pytall)  | - 2.7.12<br>- 3.4.3<br>- 3.5.5<br>- 3.6.4<br>- pypy2 5.10.0<br>- pypy3 5.10.1 | - [Common components](#common-624)<br>- virtualenv<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
+ | Ubuntu 16.04 | drydock/u16pytall:v6.2.4 | [Docker Hub](https://hub.docker.com/r/drydock/u16pytall/)<br> [GitHub](https://github.com/dry-dock/u16pytall) |- 2.7.12<br>- 3.4.8<br>- 3.5.2<br>- 3.6.4<br>- pypy2 5.10.0<br>- pypy3 5.10.1 | - [Common components](#common-624)<br>- virtualenv<br>- Java 1.8.0<br>- Node 7.10.0<br>- Ruby 2.3.3 |
+ | Ubuntu 14.04 | drydock/u14pytall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14pytall/)<br>- [GitHub](https://github.com/dry-dock/u14pytall)  | - 2.7.12<br>- 3.4.3<br>- 3.5.5<br>- 3.6.4<br>- pypy2 5.10.0<br>- pypy3 5.10.1 | - [Common components](#common-624)<br>- virtualenv<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
 
 ---
 
@@ -131,7 +133,7 @@ We have the following base images, one for each supported OS version.
 
  | OS           | Image                    | Link                                                                                                          | Language versions      | Additional packages                                                     |
  |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|------------------------|-------------------------------------------------------------------------|
- | Ubuntu 16.04 | drydock/u16cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16cppall/),<br>- [Github](https://github.com/dry-dock/u16cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 7.10.0<br>- Ruby 2.3.3 |
- | Ubuntu 14.04 | drydock/u14cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14cppall/),<br>- [Github](https://github.com/dry-dock/u14cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
+ | Ubuntu 16.04 | drydock/u16cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16cppall/),<br>- [GitHub](https://github.com/dry-dock/u16cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 7.10.0<br>- Ruby 2.3.3 |
+ | Ubuntu 14.04 | drydock/u14cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14cppall/),<br>- [GitHub](https://github.com/dry-dock/u14cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
 
 ---


### PR DESCRIPTION
#968 

And makes the 16.04/14.04 order consistent.