### PR TITLE
adds php u14 version in 6.2.4 ami docs

### DIFF
--- a/sources/platform/runtime/machine-image/ami-v624.md
+++ b/sources/platform/runtime/machine-image/ami-v624.md
@@ -96,6 +96,7 @@ We have the following base images, one for each supported OS version.
  | OS           | Image                    | Link                                                                                                          | Language versions       | Additional packages                                                                              |
  |--------------|--------------------------|---------------------------------------------------------------------------------------------------------------|-------------------------|--------------------------------------------------------------------------------------------------|
  | Ubuntu 16.04 | drydock/u16phpall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16phpall/),<br>- [Github](https://github.com/dry-dock/u16phpall) | - 5.6.32<br>- 7.0.26<br>- 7.1.12 | - [Common components](#common-624)<br>- phpenv 1.1.1-2-g615f844<br>- Java 1.8.0<br>- Node 7.10.0<br>- Ruby 2.3.3 |
+ | Ubuntu 14.04 | drydock/u14phpall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14phpall/),<br>- [Github](https://github.com/dry-dock/u14phpall) | - 5.6.32<br>- 7.0.26<br>- 7.1.12 | - [Common components](#common-624)<br>- phpenv 1.1.1-2-g615f844<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
 
 ---
 


### PR DESCRIPTION
https://github.com/Shippable/docs/issues/988