### PR TITLE
adds docs for c7cppall image

### DIFF
--- a/sources/platform/runtime/machine-image/ami-v624.md
+++ b/sources/platform/runtime/machine-image/ami-v624.md
@@ -153,5 +153,6 @@ We have the following base images, one for each supported OS version.
  | Ubuntu 16.04 | drydock/u16cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u16cppall/),<br>- [GitHub](https://github.com/dry-dock/u16cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 7.10.0<br>- Ruby 2.3.3 |
  | Ubuntu 14.04 | drydock/u14cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydock/u14cppall/),<br>- [GitHub](https://github.com/dry-dock/u14cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
   | Ubuntu 16.04 | drydockaarch64/u16cppall:v6.2.4 | - [Docker Hub](https://hub.docker.com/r/drydockaarch64/u16cppall/),<br>- [GitHub](https://github.com/dry-dock-aarch64/u16cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 4.8.7<br>- Ruby 2.3.3  |
+ | CentOs 7 | drydock/c7:master | - [Docker Hub](https://hub.docker.com/r/drydock/c7cppall/),<br>- [GitHub](https://github.com/dry-dock/c7cppall) | - gcc 7.2<br>- clang 5.0.1 | - [Common components](#common-624)<br>- Java 1.8.0<br>- Node 9.6.1<br>- Ruby 1.9.3   |
 
 ---


### PR DESCRIPTION
fixes: https://github.com/Shippable/docs/issues/996