### PR TITLE
adds link to jira documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,6 +285,7 @@ pages:
       - Google Cloud: platform/integration/gcloudKey.md
       - HipChat: platform/integration/hipchatKey.md
       - JFrog Artifactory: platform/integration/jfrog-artifactoryKey.md
+      - Jira: platform/integration/jira.md
       - Joyent Triton: platform/integration/joyentTritonKey.md
       - Key-value: platform/integration/key-value.md
       - Kubernetes: platform/integration/kubernetes.md


### PR DESCRIPTION
Fixes the broken link (http://docs.shippable.com/platform/integration/jira/) for usuage in https://github.com/Shippable/admiral/pull/2386 and in http://docs.shippable.com/platform/tutorial/integration/howto-create-jira-issues/

#### Before
Sidebar does not have Jira
![image](https://user-images.githubusercontent.com/4211715/39292777-cca9a6ec-4954-11e8-9dac-2d42066db3dc.png)

Visiting the Jira Integration page shows
![image](https://user-images.githubusercontent.com/4211715/39293057-8b78dfa2-4955-11e8-8868-c1b60ac0a691.png)


#### After
Sidebar will have jira
![image](https://user-images.githubusercontent.com/4211715/39292872-0c5355d6-4955-11e8-9354-197fa3e5ab26.png)

Visiting the Jira integration page shows
![image](https://user-images.githubusercontent.com/4211715/39293086-9f179bde-4955-11e8-8555-de43ecc99f6d.png)

