### PR TITLE
Corrects location of build badges.

### DIFF
--- a/sources/ci/build-badges.md
+++ b/sources/ci/build-badges.md
@@ -9,9 +9,7 @@ page_description: How to get embeddable build status and code coverage badges fo
 
 You can get embeddable build status and code coverage badges for your project. These provide a visual indication of project status and code coverage percentage.
 
-- Go to your Project in the UI and click on **Settings**
-
-- Click on **Badges** in the left sidebar menu.
+- Go to your Project in the UI and click on the **Badges** icon in the top right.
 
 - Select the branch you want the status for and also whether you want the **Image URL** or **Markdown** code.
 

--- a/sources/platform/visibility/project/badges.md
+++ b/sources/platform/visibility/project/badges.md
@@ -12,7 +12,7 @@ This is the place where you can get the project specific URLs to put badges on y
 
 * Click on the Subscription in the left navbar.
 
-<img src="/images/getting-started/account-settings.png" alt="Add Account Integration">
+<img src="/images/getting-started/account-settings.png" alt="Left Navbar">
 
 * Click on the project you want and then on the Project page, click on the **Badges** icon to open Settings.
 


### PR DESCRIPTION
Shippable/heap#2362

The badges are no longer under settings; there is a badges icon next to the settings icon.

![screenshot from 2018-06-05 09 45 38](https://user-images.githubusercontent.com/5492015/40990394-839bc082-68a5-11e8-99af-ab59633bccc8.png)
