### PR TITLE
add ecr policy example and fix dockeropts name in sample

### DIFF
--- a/sources/deploy/amazon-ecs.md
+++ b/sources/deploy/amazon-ecs.md
@@ -38,7 +38,7 @@ These are the key components of the assembly line diagram -
 
 * `app_image` is a **required** [image](/platform/workflow/resource/image/) resource that represents the Docker image of the app stored in Amazon ECR.
 * `op_cluster` is a **required** [cluster](/platform/workflow/resource/cluster/) resource that represents Amazon ECS cluster to which you're deploying the application.
-* `app_options` is an **optional** [dockerOptions](/platform/workflow/resource/dockeroptions/#dockeroptions) resource
+* `app_opts` is an **optional** [dockerOptions](/platform/workflow/resource/dockeroptions/#dockeroptions) resource
 that represents the options of the application container.
 * `app_env` is an **optional** [params](/platform/workflow/resource/params) resource that stores key-value pairs that are set as environment variables for consumption by the application.
 * `app_replicas` is an **optional** [replicas](/platform/workflow/resource/replicas) resource that specifies the number of instances of the container to deploy.
@@ -66,7 +66,7 @@ This file should be committed to your source control. Step 5 of the workflow bel
 * **Required:** Yes.
 * **Integrations needed:** AWS Keys, or any [supported Docker registry](/platform/integration/overview/#supported-docker-registry-integrations) if your image isn't stored in ECR.
 
-**Steps**  
+**Steps**
 
 1. Create an account integration for AWS Keys in your Shippable UI. Instructions to create an integration are here:
 
@@ -82,7 +82,7 @@ resources:
 
   - name: app_image # resource friendly name
     type: image
-    integration: aws_keys_int    #friendly name of your integration          
+    integration: aws_keys_int    #friendly name of your integration
     pointer:
       sourceName: "679404489841.dkr.ecr.us-east-1.amazonaws.com/deploy-ecs-basic"    #image name
     seed:
@@ -122,7 +122,7 @@ resources:
 
   - name: op_cluster    # resource friendly name
     type: cluster
-    integration: aws_keys_int   # friendly name of integration from step 1          
+    integration: aws_keys_int   # friendly name of integration from step 1
     pointer:
       sourceName: "deploy-ecs-cluster" # name of the actual cluster in ECS
       region: "us-east-1" # AWS region where cluster is located.
@@ -179,7 +179,7 @@ Add a `dockerOptions` resource to your [shippable.yml](/platform/workflow/config
 ```
 resources:
 
-  - name: app_options
+  - name: app_opts
     type: dockerOptions
     version:
       memory: 1024
@@ -199,7 +199,7 @@ jobs:
     type: manifest
     steps:
      - IN: app_image
-     - IN: app_options
+     - IN: app_opts
 ```
 
 ## Setting env vars

--- a/sources/platform/integration/aws-keys.md
+++ b/sources/platform/integration/aws-keys.md
@@ -140,7 +140,33 @@ And if you are adding scaling policies or AWS CloudWatch metric alarms, you will
 }
 ```
 
-For `cliConfig` resources, you should make sure that your policy allows you to perform whatever actions you plan to take in your custom script.  This could mean ECR actions to pull images, ECS actions to create deployments, EC2 actions to run instances, etc.
+For `cliConfig` resources, you should make sure that your policy allows you to perform whatever actions you plan to take in your custom script.  This could mean ECR actions to pull images, ECS actions to create deployments, EC2 actions to run instances, etc.  Here is an example ECR policy that allows login, pushing, and pulling:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetRepositoryPolicy",
+                "ecr:DescribeRepositories",
+                "ecr:ListImages",
+                "ecr:DescribeImages",
+                "ecr:BatchGetImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:PutImage"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+These settings come directly from a default AWS policay called "AmazonEC2ContainerRegistryPowerUser", which is described as "Provides full access to Amazon EC2 Container Registry repositories, but does not allow repository deletion or policy changes". A policy like this should allow any typical action you'd like to take for ECR.
 
 ## Default Environment Variables
 When you create a resource with this integration, and use it as an `IN` or `OUT` for a job that can execute user defined scripts, a set of environment variables are configured by the platform that may be useful to set the context before user defined scripts execute as part of the job. These variables are available when a resource with this integration type is used.


### PR DESCRIPTION
- correct resource names to match the image in the aws example
- add an example policy that allows for full ECR control with aws keys integration
