### PR TITLE
Remove unused reference from mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -581,7 +581,6 @@ pages:
       - Using AWS CLI to provision a self-hosted Kubernetes cluster on AWS: provision/tutorial/provision-self-kube-with-awscli.md
       - Deploying to a self-hosted Kubernetes cluster using Helm: deploy/tutorial/deploy-to-self-kube-helm.md
       - Deploying to a self-hosted Kubernetes cluster using Shippable managed jobs: deploy/tutorial/deploy-to-self-kube-shippable.md
-      - Using a private custom image with runSh jobs: platform/tutorial/workflow/use-private-custom-image-runsh.md
     - Future:
       - Provision Azure Virtual Network with Ansible: provision/tutorial/provision-azure-vnet-ansible.md
       - Provision Azure Virtual Network with Terraform: provision/tutorial/provision-azure-vnet-terraform.md


### PR DESCRIPTION
[publish_rc_docs](https://app.shippable.com/github/Shippable/jobs/publish_rc_docs/builds/5b49a2b48506c307008ead76/console) is failing --
```
ERROR   -  Error building page platform/tutorial/workflow/use-private-custom-image-runsh.md 
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/mkdocs/__main__.py", line 156, in build_command
    ), dirty=not clean)
  File "/usr/local/lib/python2.7/dist-packages/mkdocs/commands/build.py", line 380, in build
    build_pages(config, dirty=dirty)
  File "/usr/local/lib/python2.7/dist-packages/mkdocs/commands/build.py", line 333, in build_pages
    dump_json)
  File "/usr/local/lib/python2.7/dist-packages/mkdocs/commands/build.py", line 180, in _build_page
    input_content = io.open(input_path, 'r', encoding='utf-8').read()
IOError: [Errno 2] No such file or directory: '/var/lib/shippable/build/IN/docs_repo/gitRepo/sources/platform/tutorial/workflow/use-private-custom-image-runsh.md'
```

We removed the file and reference from the *.md files in [this commit](https://github.com/Shippable/docs/commit/5935ec1592a206dacb13fb5c249a193c599b57c3) but not the mkdocs.yml entry.