### PR TITLE
fix anchor jumping

### DIFF
--- a/theme/saas/static/css/shippable.css
+++ b/theme/saas/static/css/shippable.css
@@ -645,3 +645,11 @@ pre code {
 pre {
   background-color: #f8f8f8;
 }
+
+*[id]:before {
+  display: block;
+  content: " ";
+  margin-top: -75px;
+  height: 75px;
+  visibility: hidden;
+}


### PR DESCRIPTION
#1318 

The anchor title will now be visible as originally intended.  This fix was used at the suggestion of https://github.com/twbs/bootstrap/issues/1768#issuecomment-46519033
