### PR TITLE
Fixes duplicate links to "Push to Docker Registry"

### DIFF
--- a/sources/ci/push-artifacts.md
+++ b/sources/ci/push-artifacts.md
@@ -11,10 +11,11 @@ At the end of your CI workflow, you might want to push artifacts like a JAR/WAR 
 
 We have native support for many popular artifact repositories. Please click on the one you're interested in for detailed instructions on pushing your artifacts:
 
-- [Docker Registry](push-docker-registry/)
-- [JFrog Artifactory](push-to-artifactory/)
 - [Amazon S3](push-to-s3/)
+- [JFrog Artifactory](push-to-artifactory/)
+- [Docker Hub](push-docker-hub/)
 - [Amazon ECR](push-amazon-ecr/)
 - [Google Cloud](push-gcr/)
-- [Docker Registry](push-docker-registry/)
 - [Quay](push-quay/)
+- [Docker Registry](push-docker-registry/)
+


### PR DESCRIPTION
I assume one is meant to be for Docker Hub.

Also reorders links to align with the navigation sidebar links in left.