### PR TITLE
override capitalization for swagger

### DIFF
--- a/theme/saas/static/css/override-swagger.css
+++ b/theme/saas/static/css/override-swagger.css
@@ -124,6 +124,10 @@ div.swagger-ui-wrap div.info h2 {
   border-bottom: 0px !important
 }
 
+div.swagger-ui-wrap label {
+  text-transform: none !important;
+}
+
 div.swagger-ui-wrap div.info h2 a {
   text-decoration: none !important;
 }
@@ -169,4 +173,3 @@ div.swagger-ui-wrap div.container ul#resources ul.endpoints li.endpoint ul.opera
 div.swagger-ui-wrap div.container ul#resources ul.endpoints li.endpoint ul.operations li.operation.get div.heading h3 span.http_method a {
   background: #006cd1 !important;
 }
-


### PR DESCRIPTION
#1359 
![image](https://user-images.githubusercontent.com/6869398/47751754-e22e1c80-dc4f-11e8-86ef-5395b24a6254.png)

screenshot shows that the text-transform is crossed out in the "label" section from style.min.css, and set to "none" from "override-swagger"